### PR TITLE
Replace `PluginManager ` global state with injectable class

### DIFF
--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -147,6 +147,7 @@ class Cntlr:
     config: dict[str, Any] | None
     configJsonFile: str
     webCache: WebCache
+    pluginManager: PluginManager.PluginManager
     modelManager: ModelManager.ModelManager
     logger: logging.Logger | None
     logHandler: logging.Handler
@@ -289,6 +290,7 @@ class Cntlr:
 
         # start plug in server (requres web cache initialized, but not logger)
         PluginManager.init(self, loadPluginConfig=hasGui)
+        self.pluginManager = PluginManager._singleton  # type: ignore[assignment]
 
         # requires plug ins initialized
         self.modelManager = ModelManager.initialize(self)

--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -402,13 +402,14 @@ class Cntlr:
             if logFileName in ("logToPrint", "logToStdErr") and not logToBuffer:
                 self.logHandler = LogToPrintHandler(logFileName)
             elif logFileName == "logToBuffer":
-                self.logHandler = LogToBufferHandler()
+                self.logHandler = LogToBufferHandler(self)
                 setattr(self.logger, "logRefObjectProperties", logRefObjectProperties)
             elif logFileName == "logToStructuredMessage":
-                self.logHandler = StructuredMessageLogHandler()
+                self.logHandler = StructuredMessageLogHandler(self)
                 setattr(self.logger, "logRefObjectProperties", logRefObjectProperties)
             elif logFileName.endswith(".xml") or logFileName.endswith(".json") or logToBuffer:
                 self.logHandler = LogToXmlHandler(
+                    self,
                     filename=logFileName,
                     mode=logFileMode or "a",
                     logXmlMaxAttributeLength=logXmlMaxAttributeLength

--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -350,7 +350,7 @@ class Cntlr:
             Cntlr.addToLog(self, localeSetupMessage, messageCode="arelle:uiLocale", level=logging.WARNING)
 
         # Cntlr.Init after logging started
-        for pluginMethod in PluginManager.pluginClassMethods("Cntlr.Init"):
+        for pluginMethod in self.pluginManager.pluginClassMethods("Cntlr.Init"):
             pluginMethod(self)
 
     def setUiLanguage(self, locale: str | None, fallbackToDefault: bool = False) -> None:
@@ -515,7 +515,7 @@ class Cntlr:
            :param saveConfig: save the user preferences configuration
            :type saveConfig: bool
         """
-        PluginManager.save(self)
+        self.pluginManager.save(self)
 
         if self.hasGui:
             PackageManager.save(self)

--- a/arelle/Cntlr.py
+++ b/arelle/Cntlr.py
@@ -289,8 +289,7 @@ class Cntlr:
         self.webCache = WebCache(self, self.config.get("proxySettings"))
 
         # start plug in server (requres web cache initialized, but not logger)
-        PluginManager.init(self, loadPluginConfig=hasGui)
-        self.pluginManager = PluginManager._singleton  # type: ignore[assignment]
+        self.pluginManager = PluginManager.PluginManager(self, loadPluginConfig=hasGui)
 
         # requires plug ins initialized
         self.modelManager = ModelManager.initialize(self)

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -490,13 +490,13 @@ def parseArgs(args):
     for pluginCmd in preloadPlugins:
         cmd = pluginCmd.strip()
         if cmd not in ("show", "temp") and len(cmd) > 0 and cmd[0] not in ('-', '~', '+'):
-            moduleInfo = PluginManager.addPluginModule(cmd)
+            moduleInfo = cntlr.pluginManager.addPluginModule(cmd)
             if moduleInfo:
                 arellePluginModules[cmd] = moduleInfo
-                PluginManager.reset()
+                cntlr.pluginManager.reset()
 
     # add plug-in options
-    for optionsExtender in PluginManager.pluginClassMethods("CntlrCmdLine.Options"):
+    for optionsExtender in cntlr.pluginManager.pluginClassMethods("CntlrCmdLine.Options"):
         optionsExtender(parser)
     pluginLastOptionIndex = len(parser.option_list)
     pluginLastOptionsGroupIndex = len(parser.option_groups)
@@ -869,7 +869,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
                 elif cmd == "temp":
                     savePluginChanges = False
                 elif cmd.startswith("+"):
-                    moduleInfo = PluginManager.addPluginModule(cmd[1:])
+                    moduleInfo = self.pluginManager.addPluginModule(cmd[1:])
                     if moduleInfo:
                         self.addToLog(_("Addition of plug-in {0} successful.").format(moduleInfo.get("name")),
                                       messageCode="info", file=moduleInfo.get("moduleURL"))
@@ -879,13 +879,13 @@ class CntlrCmdLine(Cntlr.Cntlr):
                     else:
                         self.addToLog(_("Unable to load plug-in."), messageCode="info", file=cmd[1:])
                 elif cmd.startswith("~"):
-                    if PluginManager.reloadPluginModule(cmd[1:]):
+                    if self.pluginManager.reloadPluginModule(cmd[1:]):
                         self.addToLog(_("Reload of plug-in successful."), messageCode="info", file=cmd[1:])
                         resetPlugins = True
                     else:
                         self.addToLog(_("Unable to reload plug-in."), messageCode="info", file=cmd[1:])
                 elif cmd.startswith("-"):
-                    if PluginManager.removePluginModule(cmd[1:]):
+                    if self.pluginManager.removePluginModule(cmd[1:]):
                         self.addToLog(_("Deletion of plug-in successful."), messageCode="info", file=cmd[1:])
                         resetPlugins = True
                     else:
@@ -895,7 +895,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
                     if cmd in self.preloadedPlugins:
                         moduleInfo =  self.preloadedPlugins[cmd] # already loaded, add activation message to log below
                     else:
-                        moduleInfo = PluginManager.addPluginModule(cmd)
+                        moduleInfo = self.pluginManager.addPluginModule(cmd)
                         if moduleInfo:
                             resetPlugins = True
                             if _pluginHasCliOptions(moduleInfo):
@@ -908,18 +908,18 @@ class CntlrCmdLine(Cntlr.Cntlr):
                                       messageCode="arelle:pluginParameterError",
                                       messageArgs={"name": cmd, "file": cmd}, level=logging.ERROR)
                 if resetPlugins:
-                    PluginManager.reset()
+                    self.pluginManager.reset()
                     if savePluginChanges:
-                        PluginManager.save(self)
+                        self.pluginManager.save(self)
                 if loadPluginOptions:
                     _optionsParser = ParserForDynamicPlugins(options)
                     # add plug-in options
-                    for optionsExtender in PluginManager.pluginClassMethods("CntlrCmdLine.Options"):
+                    for optionsExtender in self.pluginManager.pluginClassMethods("CntlrCmdLine.Options"):
                         optionsExtender(_optionsParser)
 
             if showPluginModules:
                 self.addToLog(_("Plug-in modules:"), messageCode="info")
-                for i, moduleItem in enumerate(sorted(PluginManager.pluginConfig.get("modules", {}).items())):
+                for i, moduleItem in enumerate(sorted(self.pluginManager.pluginConfig.get("modules", {}).items())):
                     moduleInfo = moduleItem[1]
                     self.addToLog(_("Plug-in: {0}; author: {1}; version: {2}; status: {3}; date: {4}; description: {5}; license {6}.").format(
                                   moduleItem[0], moduleInfo.get("author"), moduleInfo.get("version"), moduleInfo.get("status"),
@@ -1103,7 +1103,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
 
         # run utility command line options that don't depend on entrypoint Files
         hasUtilityPlugin = False
-        for pluginXbrlMethod in PluginManager.pluginClassMethods("CntlrCmdLine.Utility.Run"):
+        for pluginXbrlMethod in self.pluginManager.pluginClassMethods("CntlrCmdLine.Utility.Run"):
             hasUtilityPlugin = True
             try:
                 pluginXbrlMethod(self, options, sourceZipStream=sourceZipStream, responseZipStream=responseZipStream)
@@ -1122,7 +1122,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
         _entrypointFiles = entrypointParseResult.entrypointFiles
         success = True
 
-        for pluginXbrlMethod in PluginManager.pluginClassMethods("CntlrCmdLine.Filing.Start"):
+        for pluginXbrlMethod in self.pluginManager.pluginClassMethods("CntlrCmdLine.Filing.Start"):
             pluginXbrlMethod(self, options, filesource, _entrypointFiles, sourceZipStream=sourceZipStream, responseZipStream=responseZipStream)
 
         if options.validate and filesource is not None:
@@ -1189,10 +1189,10 @@ class CntlrCmdLine(Cntlr.Cntlr):
                     if modelXbrl.errors:
                         success = False    # loading errors, don't attempt to utilize loaded DTS
                 if modelXbrl.modelDocument.type in ModelDocument.Type.TESTCASETYPES:
-                    for pluginXbrlMethod in PluginManager.pluginClassMethods("Testcases.Start"):
+                    for pluginXbrlMethod in self.pluginManager.pluginClassMethods("Testcases.Start"):
                         pluginXbrlMethod(self, options, modelXbrl)
                 else: # not a test case, probably instance or DTS
-                    for pluginXbrlMethod in PluginManager.pluginClassMethods("CntlrCmdLine.Xbrl.Loaded"):
+                    for pluginXbrlMethod in self.pluginManager.pluginClassMethods("CntlrCmdLine.Xbrl.Loaded"):
                         pluginXbrlMethod(self, options, modelXbrl, _entrypoint, responseZipStream=responseZipStream)
                     if options.saveOIMToXMLReport:
                         if modelXbrl.loadedFromOIM and modelXbrl.modelDocument is not None:
@@ -1241,7 +1241,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
                     for modelXbrl in [self.modelManager.modelXbrl] + getattr(self.modelManager.modelXbrl, "supplementalModelXbrls", []):
                         hasFormulae = modelXbrl.hasFormulae
                         isAlreadyValidated = False
-                        for pluginXbrlMethod in PluginManager.pluginClassMethods("ModelDocument.IsValidated"):
+                        for pluginXbrlMethod in self.pluginManager.pluginClassMethods("ModelDocument.IsValidated"):
                             if pluginXbrlMethod(modelXbrl): # e.g., streaming extensions already has validated
                                 isAlreadyValidated = True
                         if options.validate and not isAlreadyValidated:
@@ -1353,7 +1353,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
                         if options.arcroleTypesFile:
                             ViewFileRoleTypes.viewRoleTypes(modelXbrl, options.arcroleTypesFile, "Arcrole Types", isArcrole=True, lang=options.labelLang)
 
-                        for pluginXbrlMethod in PluginManager.pluginClassMethods("CntlrCmdLine.Xbrl.Run"):
+                        for pluginXbrlMethod in self.pluginManager.pluginClassMethods("CntlrCmdLine.Xbrl.Run"):
                             pluginXbrlMethod(self, options, modelXbrl, _entrypoint, sourceZipStream=sourceZipStream, responseZipStream=responseZipStream)
 
                 except OSError as err:
@@ -1412,7 +1412,7 @@ class CntlrCmdLine(Cntlr.Cntlr):
                         self.modelManager.close(modelXbrl)
 
         if options.validate:
-            for pluginXbrlMethod in PluginManager.pluginClassMethods("Validate.Complete"):
+            for pluginXbrlMethod in self.pluginManager.pluginClassMethods("Validate.Complete"):
                 pluginXbrlMethod(self, filesource)
 
         if filesource is not None and not options.keepOpen:
@@ -1421,9 +1421,9 @@ class CntlrCmdLine(Cntlr.Cntlr):
 
         if success:
             if options.validate:
-                for pluginXbrlMethod in PluginManager.pluginClassMethods("CntlrCmdLine.Filing.Validate"):
+                for pluginXbrlMethod in self.pluginManager.pluginClassMethods("CntlrCmdLine.Filing.Validate"):
                     pluginXbrlMethod(self, options, filesource, _entrypointFiles, sourceZipStream=sourceZipStream, responseZipStream=responseZipStream)
-            for pluginXbrlMethod in PluginManager.pluginClassMethods("CntlrCmdLine.Filing.End"):
+            for pluginXbrlMethod in self.pluginManager.pluginClassMethods("CntlrCmdLine.Filing.End"):
                 pluginXbrlMethod(self, options, filesource, _entrypointFiles, sourceZipStream=sourceZipStream, responseZipStream=responseZipStream)
         self.username = self.password = None #dereference password
         self._clearPluginData()

--- a/arelle/CntlrCmdLine.py
+++ b/arelle/CntlrCmdLine.py
@@ -643,15 +643,16 @@ def parseArgs(args):
     return runtimeOptions, arellePluginModules
 
 
-def createCntlrAndPreloadPlugins(uiLang, disablePersistentConfig, arellePluginModules) -> CntlrCmdLine:
+def createCntlrAndPreloadPlugins(uiLang, disablePersistentConfig, arellePluginModules, logFileName=None) -> CntlrCmdLine:
     """
     This function creates a cntlr and preloads all the necessary plugins.
     :param uiLang: The UI Language
     :param disablePersistentConfig: flag to determine if persistent configs should be ignored
     :param arellePluginModules: a dictionary of commands and moduleInfos
+    :param logFileName: optional log file name to use for the cntlr's logging configuration
     :return: cntlr
     """
-    cntlr = CntlrCmdLine(uiLang=uiLang, disable_persistent_config=disablePersistentConfig)
+    cntlr = CntlrCmdLine(logFileName=logFileName, uiLang=uiLang, disable_persistent_config=disablePersistentConfig)
     if arellePluginModules:
         for cmd, moduleInfo in arellePluginModules.items():
             cntlr.preloadedPlugins[cmd] = moduleInfo

--- a/arelle/CntlrWebMain.py
+++ b/arelle/CntlrWebMain.py
@@ -22,7 +22,6 @@ from arelle.CntlrCmdLine import CntlrCmdLine
 from arelle.FileSource import FileNamedBytesIO, FileNamedStringIO
 from arelle.logging.formatters.LogFormatter import LogFormatter
 from arelle.logging.handlers.LogToBufferHandler import LogToBufferHandler
-from arelle.PluginManager import pluginClassMethods
 from arelle.RuntimeOptions import RuntimeOptions
 from arelle.typing import TypeGetText
 
@@ -84,7 +83,7 @@ def startWebserver(cntlr: CntlrCmdLine, options: RuntimeOptions) -> Bottle | Non
 
     # allow plugins to replace or add to default REST API "routes"
     pluginResult = None
-    for pluginMethod in pluginClassMethods("CntlrWebMain.StartWebServer"):
+    for pluginMethod in cntlr.pluginManager.pluginClassMethods("CntlrWebMain.StartWebServer"):
         # returns a string containing "skip-routes" to block default routes and/or "skip-run" to block default app startup
         pluginResult = pluginMethod(app, cntlr, host, port, server)
         break # only provide for a single plugin of this class

--- a/arelle/CntlrWinMain.py
+++ b/arelle/CntlrWinMain.py
@@ -103,7 +103,6 @@ from arelle.FileSource import openFileSource
 from arelle.Locale import format_string, setApplicationLocale
 from arelle.ModelFormulaObject import FormulaOptions
 from arelle.oim.xml.Save import saveOimReportToXmlInstance
-from arelle.PluginManager import pluginClassMethods
 from arelle.rendering import RenderingEvaluator
 from arelle.UrlUtil import isHttpUrl
 from arelle.ValidateXbrlCalcs import ValidateCalcsMode as CalcsMode
@@ -184,7 +183,7 @@ class CntlrWinMain (Cntlr.Cntlr):
             if label is None:
                 self.fileMenu.add_separator()
             elif label == "PLUG-IN":
-                for pluginMenuExtender in pluginClassMethods(command):
+                for pluginMenuExtender in self.pluginManager.pluginClassMethods(command):
                     pluginMenuExtender(self, self.fileMenu)
                     self.fileMenuLength += 1
             else:
@@ -244,7 +243,7 @@ class CntlrWinMain (Cntlr.Cntlr):
         self.validateDuplicateFacts = None
         self.buildValidateDuplicateFactsMenu(validateMenu)
 
-        for pluginMenuExtender in pluginClassMethods("CntlrWinMain.Menu.Validation"):
+        for pluginMenuExtender in self.pluginManager.pluginClassMethods("CntlrWinMain.Menu.Validation"):
             pluginMenuExtender(self, validateMenu)
 
         formulaMenu = Menu(self.menubar, tearoff=0)
@@ -327,14 +326,14 @@ class CntlrWinMain (Cntlr.Cntlr):
 
         toolsMenu.add_command(label=_("Language..."), underline=0, command=lambda: DialogLanguage.askLanguage(self))
 
-        for pluginMenuExtender in pluginClassMethods("CntlrWinMain.Menu.Tools"):
+        for pluginMenuExtender in self.pluginManager.pluginClassMethods("CntlrWinMain.Menu.Tools"):
             pluginMenuExtender(self, toolsMenu)
         self.menubar.add_cascade(label=_("Tools"), menu=toolsMenu, underline=0)
 
         # view menu only if any plug-in additions provided
-        if any (pluginClassMethods("CntlrWinMain.Menu.View")):
+        if any (self.pluginManager.pluginClassMethods("CntlrWinMain.Menu.View")):
             viewMenu = Menu(self.menubar, tearoff=0)
-            for pluginMenuExtender in pluginClassMethods("CntlrWinMain.Menu.View"):
+            for pluginMenuExtender in self.pluginManager.pluginClassMethods("CntlrWinMain.Menu.View"):
                 pluginMenuExtender(self, viewMenu)
             self.menubar.add_cascade(label=_("View"), menu=viewMenu, underline=0)
 
@@ -352,12 +351,12 @@ class CntlrWinMain (Cntlr.Cntlr):
             if label is None:
                 helpMenu.add_separator()
             elif label == "PLUG-IN":
-                for pluginMenuExtender in pluginClassMethods(command):
+                for pluginMenuExtender in self.pluginManager.pluginClassMethods(command):
                     pluginMenuExtender(self, helpMenu)
             else:
                 helpMenu.add_command(label=label, underline=0, command=command, accelerator=shortcut_text)
                 self.parent.bind(shortcut, command)
-        for pluginMenuExtender in pluginClassMethods("CntlrWinMain.Menu.Help"):
+        for pluginMenuExtender in self.pluginManager.pluginClassMethods("CntlrWinMain.Menu.Help"):
             pluginMenuExtender(self, helpMenu)
         self.menubar.add_cascade(label=_("Help"), menu=helpMenu, underline=0)
 
@@ -408,7 +407,7 @@ class CntlrWinMain (Cntlr.Cntlr):
             else:
                 ToolTip(tbControl, text=toolTip)
             menubarColumn += 1
-        for toolbarExtender in pluginClassMethods("CntlrWinMain.Toolbar"):
+        for toolbarExtender in self.pluginManager.pluginClassMethods("CntlrWinMain.Toolbar"):
             toolbarExtender(self, toolbar)
         toolbar.grid(row=0, column=0, sticky=(N, W))
 
@@ -870,7 +869,7 @@ class CntlrWinMain (Cntlr.Cntlr):
 
     def fileOpenFile(self, filename, importToDTS=False, selectTopView=False):
         if filename:
-            for xbrlLoadedMethod in pluginClassMethods("CntlrWinMain.Xbrl.Open"):
+            for xbrlLoadedMethod in self.pluginManager.pluginClassMethods("CntlrWinMain.Xbrl.Open"):
                 filename = xbrlLoadedMethod(self, filename) # runs in GUI thread, allows mapping filename, mult return filename
             entrypointParseResult = parseEntrypointFileInput(self, filename, fallbackSelect=False)
             if not entrypointParseResult.success or entrypointParseResult.filesource is None:
@@ -912,7 +911,7 @@ class CntlrWinMain (Cntlr.Cntlr):
         if url:
             url = PackageManager.mappedUrl(url)
             self.updateFileHistory(url, False)
-            for xbrlLoadedMethod in pluginClassMethods("CntlrWinMain.Xbrl.Open"):
+            for xbrlLoadedMethod in self.pluginManager.pluginClassMethods("CntlrWinMain.Xbrl.Open"):
                 url = xbrlLoadedMethod(self, url) # runs in GUI thread, allows mapping url, mult return url
             entrypointParseResult = parseEntrypointFileInput(self, url, fallbackSelect=False)
             if not entrypointParseResult.success or entrypointParseResult.filesource is None:
@@ -950,7 +949,7 @@ class CntlrWinMain (Cntlr.Cntlr):
         loadedModels = []
         try:
             action = _("preparing entrypoints")
-            for pluginXbrlMethod in pluginClassMethods("CntlrWinMain.Filing.Start"):
+            for pluginXbrlMethod in self.pluginManager.pluginClassMethods("CntlrWinMain.Filing.Start"):
                 pluginXbrlMethod(self, filesource, entrypointFiles)
             for entrypoint in entrypointFiles:
                 entrypointFile = entrypoint.get("file", None) if isinstance(entrypoint,dict) else entrypoint
@@ -1029,7 +1028,7 @@ class CntlrWinMain (Cntlr.Cntlr):
                             os.path.basename(modelXbrl.modelDocument.uri)))
             self.setValidateTooltipText()
             if any(extViews(self, modelXbrl)
-                   for extViews in pluginClassMethods("CntlrWinMain.Xbrl.Views")):
+                   for extViews in self.pluginManager.pluginClassMethods("CntlrWinMain.Xbrl.Views")):
                 currentAction = "ext views provided"
             elif modelXbrl.modelDocument.type in ModelDocument.Type.TESTCASETYPES:
                 currentAction = "tree view of tests"
@@ -1118,7 +1117,7 @@ class CntlrWinMain (Cntlr.Cntlr):
                     topView.select()
                 self.currentView = topView
                 currentAction = "plugin method CntlrWinMain.Xbrl.Loaded"
-                for xbrlLoadedMethod in pluginClassMethods("CntlrWinMain.Xbrl.Loaded"):
+                for xbrlLoadedMethod in self.pluginManager.pluginClassMethods("CntlrWinMain.Xbrl.Loaded"):
                     xbrlLoadedMethod(self, modelXbrl, attach) # runs in GUI thread
         except Exception as err:
             msg = _("Exception preparing {0}: {1}, at {2}").format(
@@ -1219,7 +1218,7 @@ class CntlrWinMain (Cntlr.Cntlr):
             if loadedModelXbrl.modelDocument:
                 startedAt = time.time()
                 if loadedModelXbrl.modelDocument.type in ModelDocument.Type.TESTCASETYPES:
-                    for pluginXbrlMethod in pluginClassMethods("Testcases.Start"):
+                    for pluginXbrlMethod in self.pluginManager.pluginClassMethods("Testcases.Start"):
                         pluginXbrlMethod(self, None, loadedModelXbrl)
                 if loadedModelXbrl.fileSource not in validatedFileSources:
                     validatedFileSources.add(loadedModelXbrl.fileSource)

--- a/arelle/CompareInstance.py
+++ b/arelle/CompareInstance.py
@@ -9,7 +9,6 @@ from arelle.ModelDtsObject import ModelResource
 from arelle.ModelInstanceObject import ModelFact
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelXbrl import ModelXbrl, load
-from arelle.PluginManager import pluginClassMethods
 from arelle.XmlUtil import collapseWhitespace
 from arelle.typing import TypeGetText
 
@@ -52,7 +51,7 @@ def _compareInstance(originalInstance: ModelXbrl, expectedInstance: ModelXbrl, t
                         modelXbrl=originalInstance,
                         file=originalInstance.uri)
         return
-    for pluginXbrlMethod in pluginClassMethods("CompareInstance.Loaded"):
+    for pluginXbrlMethod in originalInstance.modelManager.cntlr.pluginManager.pluginClassMethods("CompareInstance.Loaded"):
         pluginXbrlMethod(expectedInstance, targetInstance)
     if len(expectedInstance.facts) != len(targetInstance.facts):
         targetInstance.error("compareInstance:resultFactCounts",

--- a/arelle/DialogOpenArchive.py
+++ b/arelle/DialogOpenArchive.py
@@ -14,7 +14,6 @@ from arelle.CntlrWinTooltip import ToolTip
 from arelle.UrlUtil import isHttpUrl
 from arelle.PackageManager import parsePackage
 from arelle.PythonUtil import attrdict
-from arelle import PluginManager
 
 '''
 caller checks accepted, if True, caller retrieves url

--- a/arelle/DialogPluginManager.py
+++ b/arelle/DialogPluginManager.py
@@ -32,7 +32,7 @@ def dialogPluginManager(mainWin):
 
 def backgroundCheckForUpdates(cntlr):
     cntlr.showStatus(_("Checking for updates to plug-ins")) # clear web loading status
-    modulesWithNewerFileDates = PluginManager.modulesWithNewerFileDates()
+    modulesWithNewerFileDates = cntlr.pluginManager.modulesWithNewerFileDates()
     if modulesWithNewerFileDates:
         cntlr.showStatus(_("Updates are available for these plug-ins: {0}")
                               .format(', '.join(modulesWithNewerFileDates)), clearAfter=5000)
@@ -51,7 +51,7 @@ class DialogPluginManager(Toplevel):
         self.cntlr = mainWin
 
         # copy plugins for temporary display
-        self.pluginConfig = PluginManager.pluginConfig
+        self.pluginConfig = self.cntlr.pluginManager.pluginConfig
         self.pluginConfigChanged = False
         self.uiClassMethodsChanged = False
         self.modelClassesChanged = False
@@ -283,9 +283,9 @@ class DialogPluginManager(Toplevel):
             del self.pluginConfig["classes"][_orphanedClassName]
 
         if self.pluginConfigChanged:
-            PluginManager.pluginConfig = self.pluginConfig
-            PluginManager.pluginConfigChanged = True
-            PluginManager.reset()  # force reloading of modules
+            self.cntlr.pluginManager.pluginConfig = self.pluginConfig
+            self.cntlr.pluginManager.pluginConfigChanged = True
+            self.cntlr.pluginManager.reset()  # force reloading of modules
         if self.uiClassMethodsChanged or self.modelClassesChanged or self.customTransformsChanged or self.disclosureSystemTypesChanged or self.hostSystemFeaturesChanged:  # may require reloading UI
             affectedItems = ""
             if self.uiClassMethodsChanged:
@@ -428,7 +428,7 @@ class DialogPluginManager(Toplevel):
         if selectedPath:
             if selectedPath.startswith(self.cntlr.pluginDir):
                 selectedPath = selectedPath[len(self.cntlr.pluginDir)+1:]
-            moduleInfo = PluginManager.moduleModuleInfo(moduleURL=selectedPath)
+            moduleInfo = self.cntlr.pluginManager.moduleModuleInfo(moduleURL=selectedPath)
             self.loadFoundModuleInfo(moduleInfo, selectedPath)
 
     def browseLocally(self):
@@ -447,14 +447,14 @@ class DialogPluginManager(Toplevel):
             #    os.path.isfile(filename)):
             #    filename = os.path.dirname(filename) # refer to the package instead
             self.cntlr.config["pluginOpenDir"] = os.path.dirname(filename)
-            moduleInfo = PluginManager.moduleModuleInfo(moduleURL=filename)
+            moduleInfo = self.cntlr.pluginManager.moduleModuleInfo(moduleURL=filename)
             self.loadFoundModuleInfo(moduleInfo, filename)
 
 
     def findOnWeb(self):
         url = DialogURL.askURL(self)
         if url:  # url is the in-cache or local file
-            moduleInfo = PluginManager.moduleModuleInfo(moduleURL=url)
+            moduleInfo = self.cntlr.pluginManager.moduleModuleInfo(moduleURL=url)
             self.cntlr.showStatus("") # clear web loading status
             self.loadFoundModuleInfo(moduleInfo, url)
 
@@ -561,7 +561,7 @@ class DialogPluginManager(Toplevel):
         if self.selectedModule in self.pluginConfig["modules"]:
             url = self.pluginConfig["modules"][self.selectedModule].get("moduleURL")
             if url:
-                moduleInfo = PluginManager.moduleModuleInfo(moduleURL=url, reload=True)
+                moduleInfo = self.cntlr.pluginManager.moduleModuleInfo(moduleURL=url, reload=True)
                 if moduleInfo:
                     if self.checkIfImported(moduleInfo):
                         return;

--- a/arelle/DialogPluginManager.py
+++ b/arelle/DialogPluginManager.py
@@ -421,7 +421,7 @@ class DialogPluginManager(Toplevel):
         return choiceTuples
 
     def selectLocally(self):
-        entryPointRefs = EntryPointRef.discoverAll()
+        entryPointRefs = EntryPointRef.discoverAll(plugin_manager=self.cntlr.pluginManager)
         choiceTuples = self._generateChoiceTuples(entryPointRefs)
 
         selectedPath = DialogOpenArchive.selectPlugin(self, choiceTuples)

--- a/arelle/DialogRssWatch.py
+++ b/arelle/DialogRssWatch.py
@@ -13,7 +13,6 @@ from arelle.ModelValue import dateTime
 from arelle import XmlUtil
 from arelle.UiUtil import gridCell, gridCombobox, label, checkbox
 from arelle.CntlrWinTooltip import ToolTip
-from arelle.PluginManager import pluginClassMethods
 from arelle.UrlUtil import isValidAbsolute
 from arelle.ValidateXbrlCalcs import ValidateCalcsMode as CalcsMode
 
@@ -81,7 +80,7 @@ class DialogRssWatch(Toplevel):
         chooseFormulaFileButton.grid(row=row, column=3, sticky=W)
         row += 1
         openDatabaseImage = PhotoImage(file=os.path.join(mainWin.imagesDir, "toolbarOpenDatabase.gif"))
-        for pluginXbrlMethod in pluginClassMethods("DialogRssWatch.FileChoices"):
+        for pluginXbrlMethod in self.mainWin.pluginManager.pluginClassMethods("DialogRssWatch.FileChoices"):
             pluginXbrlMethod(self, frame, row, options, mainWin, openFileImage, openDatabaseImage)
             row += 1
         label(frame, 1, row, "Log file:")
@@ -133,7 +132,7 @@ class DialogRssWatch(Toplevel):
            # Note: if adding to this list keep ModelFormulaObject.FormulaOptions in sync
         )
         row += 1
-        for pluginXbrlMethod in pluginClassMethods("DialogRssWatch.ValidateChoices"):
+        for pluginXbrlMethod in self.mainWin.pluginManager.pluginClassMethods("DialogRssWatch.ValidateChoices"):
             pluginXbrlMethod(self, frame, row, options, mainWin)
             row += 1
         label(frame, 2, row, "Alert on:")

--- a/arelle/DisclosureSystem.py
+++ b/arelle/DisclosureSystem.py
@@ -6,7 +6,6 @@ import regex as re
 from collections import defaultdict
 from lxml import etree
 from arelle import UrlUtil
-from arelle.PluginManager import pluginClassMethods
 from arelle.UrlUtil import isHttpUrl
 
 def compileAttrPattern(elt, attrName, flags=None, patternIfNoAttr=""):
@@ -56,7 +55,7 @@ class DisclosureSystem:
         self.HMRC = False
         self.SBRNL = False
         self.pluginTypes = set()
-        for pluginXbrlMethod in pluginClassMethods("DisclosureSystem.Types"):
+        for pluginXbrlMethod in self.modelManager.cntlr.pluginManager.pluginClassMethods("DisclosureSystem.Types"):
             for typeName, typeTestVariable in pluginXbrlMethod(self):
                 setattr(self, typeTestVariable, False)
                 self.pluginTypes.add(typeName)
@@ -112,7 +111,7 @@ class DisclosureSystem:
     def urls(self):
         _urls = [os.path.join(self.modelManager.cntlr.configDir, "disclosuresystems.xml")]
         # get custom config xml file url, insert before main url in reverse order
-        for pluginXbrlMethod in pluginClassMethods("DisclosureSystem.ConfigURL"):
+        for pluginXbrlMethod in self.modelManager.cntlr.pluginManager.pluginClassMethods("DisclosureSystem.ConfigURL"):
             _urls.insert(0, pluginXbrlMethod(self))
         return _urls
 
@@ -178,7 +177,7 @@ class DisclosureSystem:
                                     self.EFMorGFM = self.EFM or self.GFM
                                     self.HMRC = self.validationType == "HMRC"
                                     self.SBRNL = self.validationType == "SBR.NL"
-                                for pluginXbrlMethod in pluginClassMethods("DisclosureSystem.Types"):
+                                for pluginXbrlMethod in self.modelManager.cntlr.pluginManager.pluginClassMethods("DisclosureSystem.Types"):
                                     for typeName, typeTestVariable in pluginXbrlMethod(self):
                                         setattr(self, typeTestVariable, self.validationType == typeName)
                                 self.validateFileText = dsElt.get("validateFileText") == "true"

--- a/arelle/ErrorManager.py
+++ b/arelle/ErrorManager.py
@@ -13,7 +13,6 @@ from arelle import UrlUtil, XmlUtil, ModelValue, XbrlConst
 from arelle.FileSource import FileSource
 from arelle.Locale import format_string
 from arelle.ModelObject import ModelObject, ObjectPropertyViewWrapper
-from arelle.PluginManager import hasPluginWithHook, pluginClassMethods
 from arelle.PythonUtil import flattenSequence
 
 if TYPE_CHECKING:
@@ -111,9 +110,9 @@ class ErrorManager:
             self._errors.append(args["assertionResults"])
             return
         if self.logHasRelevelerPlugin is None:
-            self.logHasRelevelerPlugin = hasPluginWithHook("Logging.Severity.Releveler")
+            self.logHasRelevelerPlugin = self._modelManager.cntlr.pluginManager.hasPluginWithHook("Logging.Severity.Releveler")
         if sourceModelXbrl is not None and self.logHasRelevelerPlugin:
-            for pluginXbrlMethod in pluginClassMethods("Logging.Severity.Releveler"):
+            for pluginXbrlMethod in self._modelManager.cntlr.pluginManager.pluginClassMethods("Logging.Severity.Releveler"):
                 level, messageCode = pluginXbrlMethod(sourceModelXbrl, level, messageCode, args) # args must be passed as dict because it may contain modelXbrl or messageCode key value
         if (messageCode and
                 (not messageCodeFilter or messageCodeFilter.match(messageCode)) and
@@ -227,9 +226,9 @@ class ErrorManager:
                                     ref["properties"] = propValues(arg.propertyView)
                                 except AttributeError:
                                     pass # is a default properties entry appropriate or needed?
-                            if any(True for m in pluginClassMethods("Logging.Ref.Properties")):
+                            if any(True for m in self._modelManager.cntlr.pluginManager.pluginClassMethods("Logging.Ref.Properties")):
                                 refProperties: Any = ref.get("properties", {})
-                                for pluginXbrlMethod in pluginClassMethods("Logging.Ref.Properties"):
+                                for pluginXbrlMethod in self._modelManager.cntlr.pluginManager.pluginClassMethods("Logging.Ref.Properties"):
                                     pluginXbrlMethod(arg, refProperties, codedArgs)
                                 if refProperties:
                                     ref["properties"] = refProperties
@@ -239,9 +238,9 @@ class ErrorManager:
                                 ref["sourceLine"] = arg.sourceline
                             except AttributeError:
                                 pass # arg may not have sourceline, ignore if so
-                        if any(True for m in pluginClassMethods("Logging.Ref.Attributes")):
+                        if any(True for m in self._modelManager.cntlr.pluginManager.pluginClassMethods("Logging.Ref.Attributes")):
                             refAttributes: dict[str, str] = {}
-                            for pluginXbrlMethod in pluginClassMethods("Logging.Ref.Attributes"):
+                            for pluginXbrlMethod in self._modelManager.cntlr.pluginManager.pluginClassMethods("Logging.Ref.Attributes"):
                                 pluginXbrlMethod(arg, refAttributes, codedArgs)
                             if refAttributes:
                                 ref["customAttributes"] = refAttributes
@@ -287,7 +286,7 @@ class ErrorManager:
                 else:
                     file = ""
             extras["refs"] = [{"href": file}]
-        for pluginXbrlMethod in pluginClassMethods("Logging.Message.Parameters"):
+        for pluginXbrlMethod in self._modelManager.cntlr.pluginManager.pluginClassMethods("Logging.Message.Parameters"):
             # plug in can rewrite msg string or return msg if not altering msg
             msg = pluginXbrlMethod(messageCode, msg, modelObjectArgs, fmtArgs) or msg
         return (messageCode,

--- a/arelle/FileSource.py
+++ b/arelle/FileSource.py
@@ -13,12 +13,11 @@ import struct
 import tarfile
 import zipfile
 import zlib
-from typing import IO, TYPE_CHECKING, Any, BinaryIO, Optional, TextIO, cast
+from typing import IO, TYPE_CHECKING, Any, BinaryIO, Optional, TextIO, cast, Iterator, Callable
 
 import regex as re
 from lxml import etree
 
-import arelle.PluginManager
 from arelle import PackageManager, XmlUtil
 from arelle.PythonUtil import isLegacyAbs
 from arelle.packages.report.DetectReportPackage import isReportPackageExtension
@@ -660,7 +659,7 @@ class FileSource:
                             break
 
         # custom overrides for decription, etc
-        for pluginMethod in arelle.PluginManager.pluginClassMethods("FileSource.File"):
+        for pluginMethod in self.pluginClassMethods("FileSource.File"):
             fileResult = pluginMethod(self.cntlr, filepath, binary, stripDeclaration)
             if fileResult is not None:
                 return fileResult # type: ignore[no-any-return]
@@ -713,7 +712,7 @@ class FileSource:
                 return archiveFileName.replace("\\","/") in archiveFileSource.dir
 
         # custom overrides for decription, etc
-        for pluginMethod in arelle.PluginManager.pluginClassMethods("FileSource.Exists"):
+        for pluginMethod in self.pluginClassMethods("FileSource.Exists"):
             existsResult = pluginMethod(self.cntlr, filepath)
             if existsResult is not None:
                 return cast(bool, existsResult)
@@ -846,6 +845,13 @@ class FileSource:
         if isinstance(self.url, list):
             return [os.path.basename(url) for url in self.url]
         return None
+
+    def pluginClassMethods(self, className: str) -> Iterator[Callable[..., Any]]:
+        if self.cntlr and hasattr(self.cntlr, 'pluginManager'):
+            yield from self.cntlr.pluginManager.pluginClassMethods(className)
+            return
+        yield from iter(())
+
 
 def openFileStream(
     cntlr: Cntlr | None, filepath: str, mode: str = "r", encoding: str | None = None

--- a/arelle/FunctionIxt.py
+++ b/arelle/FunctionIxt.py
@@ -4,7 +4,6 @@ See COPYRIGHT.md for copyright information.
 import regex as re
 
 from arelle.ModelValue import QName
-from arelle.PluginManager import pluginClassMethods
 from arelle.formula.XPathParser import OperationDef
 from arelle.XmlValidate import decimalPattern
 from arelle.formula import XPathContext

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -19,7 +19,7 @@ from arelle.ModelDtsObject import ModelLink
 from arelle.ModelInstanceObject import ModelFact
 from arelle.ModelObjectFactory import parser
 from arelle.PrototypeDtsObject import LinkPrototype, LocPrototype, ArcPrototype, DocumentPrototype, PrototypeElementTree
-from arelle.PluginManager import pluginClassMethods
+from arelle.PluginManager import pluginClassMethods as _pluginClassMethods  # retained for close() where modelXbrl is dereferenced
 from arelle.PythonUtil import OrderedDefaultDict, isLegacyAbs, normalizeSpace
 from arelle.XhtmlValidate import ixMsgCode
 from arelle.XmlValidateConst import VALID
@@ -139,7 +139,7 @@ def load(modelXbrl, uri, base=None, referringElement=None, isEntry=False, isDisc
         return None
 
     isPullLoadable = any(pluginMethod(modelXbrl, mappedUri, normalizedUri, filepath, isEntry=isEntry, namespace=namespace, **kwargs)
-                         for pluginMethod in pluginClassMethods("ModelDocument.IsPullLoadable"))
+                         for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelDocument.IsPullLoadable"))
 
     if not isPullLoadable and os.path.splitext(filepath)[1] in (".xlsx", ".xls"):
         modelXbrl.error("FileNotLoadable",
@@ -152,7 +152,7 @@ def load(modelXbrl, uri, base=None, referringElement=None, isEntry=False, isDisc
     modelXbrl.modelManager.showStatus(_("parsing {0}").format(uri))
     file = None
     try:
-        for pluginMethod in pluginClassMethods("ModelDocument.PullLoader"):
+        for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelDocument.PullLoader"):
             # assumes not possible to check file in string format or not all available at once
             modelDocument = pluginMethod(modelXbrl, normalizedUri, filepath, isEntry=isEntry, namespace=namespace, **kwargs)
             if isinstance(modelDocument, Exception):
@@ -182,7 +182,7 @@ def load(modelXbrl, uri, base=None, referringElement=None, isEntry=False, isDisc
             file, _encoding = modelXbrl.fileSource.file(filepath, stripDeclaration=True)
         xmlDocument = None
         isPluginParserDocument = False
-        for pluginMethod in pluginClassMethods("ModelDocument.CustomLoader"):
+        for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelDocument.CustomLoader"):
             modelDocument = pluginMethod(modelXbrl, file, mappedUri, filepath)
             if modelDocument is not None:
                 file.close()
@@ -334,7 +334,7 @@ def load(modelXbrl, uri, base=None, referringElement=None, isEntry=False, isDisc
             # any xml document can be an inline document, only html and xhtml are found above
             _type = Type.INLINEXBRL
         else:
-            for pluginMethod in pluginClassMethods("ModelDocument.IdentifyType"):
+            for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelDocument.IdentifyType"):
                 _identifiedType = pluginMethod(modelXbrl, rootNode, filepath)
                 if _identifiedType is not None:
                     _type, _class, rootNode = _identifiedType
@@ -370,7 +370,7 @@ def load(modelXbrl, uri, base=None, referringElement=None, isEntry=False, isDisc
 
         # discovery (parsing)
         if any(pluginMethod(modelDocument)
-               for pluginMethod in pluginClassMethods("ModelDocument.Discover")):
+               for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelDocument.Discover")):
             pass # discovery was performed by plug-in, we're done
         elif _type == Type.SCHEMA:
             modelDocument.schemaDiscover(rootNode, isIncluded, isSupplemental, namespace)
@@ -773,7 +773,7 @@ class ModelDocument(ModelDocumentBase):
         if visited is None: visited = []
         visited.append(self)
         # note that self.modelXbrl has been closed/dereferenced already, do not use in plug in
-        for pluginMethod in pluginClassMethods("ModelDocument.CustomCloser"):
+        for pluginMethod in _pluginClassMethods("ModelDocument.CustomCloser"):
             pluginMethod(self)
         try:
             for referencedDocument, modelDocumentReference in self.referencesDocument.items():
@@ -1231,7 +1231,7 @@ class ModelDocument(ModelDocumentBase):
                 else:
                     _newDoc = load
                 if urlRewritePluginClass:
-                    for pluginMethod in pluginClassMethods(urlRewritePluginClass):
+                    for pluginMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods(urlRewritePluginClass):
                         url = pluginMethod(self, url)
                 doc = _newDoc(self.modelXbrl, url, isDiscovered=not nonDTS, base=self.baseForElement(element), referringElement=element)
                 if not nonDTS and doc is not None:
@@ -1346,14 +1346,14 @@ class ModelDocument(ModelDocumentBase):
         self.htmlBase = htmlBase
         ixdsTarget = getattr(self.modelXbrl, "ixdsTarget", None)
         if all(pluginMethod(self.modelXbrl)
-               for pluginMethod in pluginClassMethods("ModelDocument.DiscoverIxdsDts")):
+               for pluginMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelDocument.DiscoverIxdsDts")):
             # load referenced schemas and linkbases (before validating inline HTML
             for inlineElement in htmlElement.iterdescendants(tag=ixNStag + "references"):
                 if inlineElement.get("target") == ixdsTarget:
                     self.schemaLinkbaseRefsDiscover(inlineElement)
                     xmlValidate(self.modelXbrl, inlineElement) # validate instance elements
         # validate resources only if no possibility of multi-document ixds for which ix:references not encountered yet
-        if len(list(pluginClassMethods("ModelDocument.SelectIxdsTarget"))) == 0:
+        if len(list(self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelDocument.SelectIxdsTarget"))) == 0:
             for inlineElement in htmlElement.iterdescendants(tag=ixNStag + "resources"):
                 xmlValidate(self.modelXbrl, inlineElement) # validate instance elements
         # with DTS loaded, now validate inline HTML (so schema definition of facts is available)
@@ -1465,7 +1465,7 @@ class ModelDocument(ModelDocumentBase):
 # modelIxdsDocument is an inlineDocumentSet or entry inline document (if not a document set)
 #   note that multi-target and multi-instance facts may have html elements belonging to primary ixds instead of this instance ixds
 def inlineIxdsDiscover(modelXbrl, modelIxdsDocument, setTargetModelXbrl=False, **kwargs):
-    for pluginMethod in pluginClassMethods("ModelDocument.SelectIxdsTarget"):
+    for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelDocument.SelectIxdsTarget"):
         pluginMethod(modelXbrl, modelIxdsDocument, **kwargs)
     # extract for a single target document
     ixdsTarget = getattr(modelXbrl, "ixdsTarget", None)
@@ -2126,7 +2126,7 @@ def inlineIxdsDiscover(modelXbrl, modelIxdsDocument, setTargetModelXbrl=False, *
         modelIxdsDocument.targetXbrlRootElement = modelXbrl.ixTargetRootElements[ixdsTarget]
         modelIxdsDocument.targetXbrlElementTree = PrototypeElementTree(modelIxdsDocument.targetXbrlRootElement)
 
-    for pluginMethod in pluginClassMethods("ModelDocument.IxdsTargetDiscovered"):
+    for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelDocument.IxdsTargetDiscovered"):
         pluginMethod(modelXbrl, modelIxdsDocument)
 
 class LoadingException(Exception):

--- a/arelle/ModelDocument.py
+++ b/arelle/ModelDocument.py
@@ -19,7 +19,6 @@ from arelle.ModelDtsObject import ModelLink
 from arelle.ModelInstanceObject import ModelFact
 from arelle.ModelObjectFactory import parser
 from arelle.PrototypeDtsObject import LinkPrototype, LocPrototype, ArcPrototype, DocumentPrototype, PrototypeElementTree
-from arelle.PluginManager import pluginClassMethods as _pluginClassMethods  # retained for close() where modelXbrl is dereferenced
 from arelle.PythonUtil import OrderedDefaultDict, isLegacyAbs, normalizeSpace
 from arelle.XhtmlValidate import ixMsgCode
 from arelle.XmlValidateConst import VALID
@@ -663,6 +662,9 @@ class ModelDocument(ModelDocumentBase):
         self.inDTS = False
         self.definesUTR = False
         self.isModified = False
+        # The "ModelDocument.CustomCloser" plugin hooked is invoked after modelXbrl is dereferenced
+        # Store a reference to the plugin manager so that hook can be called, then deference it.
+        self.pluginManager = modelXbrl.modelManager.cntlr.pluginManager
 
 
     def objectId(self,refId=""):
@@ -773,8 +775,10 @@ class ModelDocument(ModelDocumentBase):
         if visited is None: visited = []
         visited.append(self)
         # note that self.modelXbrl has been closed/dereferenced already, do not use in plug in
-        for pluginMethod in _pluginClassMethods("ModelDocument.CustomCloser"):
+        # we have a reference to the modelXbrl's PluginManager and need to dereference after using
+        for pluginMethod in self.pluginManager.pluginClassMethods("ModelDocument.CustomCloser"):
             pluginMethod(self)
+        self.pluginManager = None
         try:
             for referencedDocument, modelDocumentReference in self.referencesDocument.items():
                 if referencedDocument not in visited:

--- a/arelle/ModelManager.py
+++ b/arelle/ModelManager.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 import gc, sys, traceback, logging
 from arelle import ModelXbrl, Validate, DisclosureSystem, PackageManager, ValidateXbrlCalcs, ValidateDuplicateFacts
 from arelle.ModelFormulaObject import FormulaOptions
-from arelle.PluginManager import pluginClassMethods
 from arelle.ValidateXbrlDTS import ValidateBaseTaxonomiesMode
 from arelle.typing import LocaleDict
 
@@ -160,7 +159,7 @@ class ModelManager:
             pass # filesource may be a string, which has no url attribute
         self.filesource = filesource
         modelXbrl = None # loaded modelXbrl
-        for customLoader in pluginClassMethods("ModelManager.Load"):
+        for customLoader in self.cntlr.pluginManager.pluginClassMethods("ModelManager.Load"):
             modelXbrl = customLoader(self, filesource, **kwargs)
             if modelXbrl is not None:
                 break # custom loader did the loading
@@ -254,5 +253,5 @@ class ModelManager:
     def loadCustomTransforms(self):
         if self.customTransforms is None:
             self.customTransforms = {}
-            for pluginMethod in pluginClassMethods("ModelManager.LoadCustomTransforms"):
+            for pluginMethod in self.cntlr.pluginManager.pluginClassMethods("ModelManager.LoadCustomTransforms"):
                 pluginMethod(self.customTransforms)

--- a/arelle/ModelTestcaseObject.py
+++ b/arelle/ModelTestcaseObject.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING
 from arelle import XmlUtil, XbrlConst, ModelValue
 from arelle.conformance.Constants import CONFORMANCE_SUITE_ID_OVERRIDES
 from arelle.ModelObject import ModelObject
-from arelle.PluginManager import pluginClassMethods
 
 if TYPE_CHECKING:
     from arelle import FileSource
@@ -120,7 +119,7 @@ class ModelTestcaseVariation(ModelObject):
             self.readMeFirstElements = []
             # first look if any plugin method to get readme first URIs
             if not any(pluginXbrlMethod(self)
-                       for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ReadMeFirstUris")):
+                       for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelTestcaseVariation.ReadMeFirstUris")):
                 if self.localName == "testGroup":  #w3c testcase
                     instanceTestElement = XmlUtil.descendant(self, None, "instanceTest")
                     if instanceTestElement is not None: # take instance first
@@ -201,7 +200,7 @@ class ModelTestcaseVariation(ModelObject):
 
     @property
     def resultXbrlInstanceUri(self):
-        for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ResultXbrlInstanceUri"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelTestcaseVariation.ResultXbrlInstanceUri"):
             resultInstanceUri = pluginXbrlMethod(self)
             if resultInstanceUri is not None:
                 return resultInstanceUri or None # (empty string returns None)
@@ -309,7 +308,7 @@ class ModelTestcaseVariation(ModelObject):
 
     @property
     def expected(self):
-        for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ExpectedResult"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelTestcaseVariation.ExpectedResult"):
             expected = pluginXbrlMethod(self)
             if expected:
                 return expected
@@ -393,7 +392,7 @@ class ModelTestcaseVariation(ModelObject):
 
     @property
     def expectedCount(self):
-        for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ExpectedCount"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelTestcaseVariation.ExpectedCount"):
             _count = pluginXbrlMethod(self)
             if _count is not None: # ignore plug in if not a plug-in-recognized test case
                 return _count
@@ -409,7 +408,7 @@ class ModelTestcaseVariation(ModelObject):
 
     @property
     def severityLevel(self):
-        for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ExpectedSeverity"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelTestcaseVariation.ExpectedSeverity"):
             severityLevelName = pluginXbrlMethod(self)
             if severityLevelName: # ignore plug in if not a plug-in-recognized test case
                 return logging._checkLevel(severityLevelName)

--- a/arelle/ModelXbrl.py
+++ b/arelle/ModelXbrl.py
@@ -20,7 +20,6 @@ from arelle.ErrorManager import ErrorManager
 from arelle.Locale import format_string
 from arelle.ModelObject import ModelObject
 from arelle.ModelValue import dateUnionEqual
-from arelle.PluginManager import pluginClassMethods
 from arelle.PrototypeInstanceObject import FactPrototype, DimValuePrototype
 from arelle.UrlUtil import isHttpUrl
 from arelle.ValidateXbrlDimensions import isFactDimensionallyValid
@@ -102,7 +101,7 @@ def load(modelManager: ModelManager, url: str | FileSourceClass, nextaction: str
     #uncomment for trial use of lxml xml schema validation of entry document
     #XmlValidate.xmlValidate(modelXbrl.modelDocument)
     modelManager.cntlr.webCache.saveUrlCheckTimes()
-    for pluginXbrlMethod in pluginClassMethods("ModelXbrl.LoadComplete"):
+    for pluginXbrlMethod in modelManager.cntlr.pluginManager.pluginClassMethods("ModelXbrl.LoadComplete"):
         pluginXbrlMethod(modelXbrl)
     modelManager.showStatus(_("xbrl loading finished, {0}...").format(nextaction))
     return modelXbrl
@@ -360,13 +359,13 @@ class ModelXbrl:
         self.formulaOutputInstance: ModelXbrl | None = None
         self.logger: logging.Logger | None = self.modelManager.cntlr.logger
         self.logRefObjectProperties: bool = getattr(self.logger, "logRefObjectProperties", False)
-        self.logRefHasPluginAttrs: bool = any(True for m in pluginClassMethods("Logging.Ref.Attributes"))
-        self.logRefHasPluginProperties: bool = any(True for m in pluginClassMethods("Logging.Ref.Properties"))
+        self.logRefHasPluginAttrs: bool = any(True for m in self.modelManager.cntlr.pluginManager.pluginClassMethods("Logging.Ref.Attributes"))
+        self.logRefHasPluginProperties: bool = any(True for m in self.modelManager.cntlr.pluginManager.pluginClassMethods("Logging.Ref.Properties"))
         self.profileStats: dict[str, tuple[int, float, float | int]] = {}
         self.schemaDocsToValidate: set[ModelDocumentClass] = set()
         self.modelXbrl = self  # for consistency in addressing modelXbrl
         self.arelleUnitTests: dict[str, str] = {}  # unit test entries (usually from processing instructions
-        for pluginXbrlMethod in pluginClassMethods("ModelXbrl.Init"):
+        for pluginXbrlMethod in self.modelManager.cntlr.pluginManager.pluginClassMethods("ModelXbrl.Init"):
             pluginXbrlMethod(self)
 
     def close(self) -> None:
@@ -464,7 +463,7 @@ class ModelXbrl:
 
     def roleTypeName(self, roleURI: str, lang: str | None = None) -> str:
         # authority-specific role type name
-        for pluginXbrlMethod in pluginClassMethods("ModelXbrl.RoleTypeName"):
+        for pluginXbrlMethod in self.modelManager.cntlr.pluginManager.pluginClassMethods("ModelXbrl.RoleTypeName"):
             _roleTypeName = pluginXbrlMethod(self, roleURI, lang)
             if _roleTypeName:
                 return cast(str, _roleTypeName)

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -626,10 +626,10 @@ def loadModule(moduleInfo: dict[TypeModuleInfoKey, Any], packagePrefix: str="") 
                     try:
                         _gettext = gettext.translation(pluginInfo['localeDomain'], localeDir, getLanguageCodes())
                     except OSError:
-                        def _gettext(x):
+                        def _gettext(x: Any) -> Any: # type: ignore[misc]
                             return x # no translation
                 else:
-                    def _gettext(x):
+                    def _gettext(x: Any) -> Any: # type: ignore[misc]
                         return x
                 for key, value in pluginInfo.items():
                     if key == 'name':
@@ -641,7 +641,7 @@ def loadModule(moduleInfo: dict[TypeModuleInfoKey, Any], packagePrefix: str="") 
                             classModuleNames.append(name)
                     if key == 'ModelObjectFactory.ElementSubstitutionClasses':
                         elementSubstitutionClasses = value
-                module._ = _gettext
+                module._ = _gettext # type: ignore[attr-defined]
                 global pluginConfigChanged
                 pluginConfigChanged = True
             if elementSubstitutionClasses:

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -21,7 +21,7 @@ from importlib.metadata import EntryPoint, entry_points
 from numbers import Number
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, Union
 
 import arelle.FileSource
 from arelle.Locale import getLanguageCodes
@@ -57,6 +57,10 @@ pluginMethodsForClasses: dict[str, Any] = {}
 _pluginBase = None
 EMPTYLIST: list[Any] = []
 _ERROR_MESSAGE_IMPORT_TEMPLATE = "Unable to load module {}"
+
+TypeModuleInfoKey = Union[
+    str, bytes, int, float, complex, types.EllipsisType, None
+]
 
 def init(cntlr: Cntlr, loadPluginConfig: bool = True) -> None:
     global pluginJsonFile, pluginConfig, pluginTraceFileLogger, modulePluginInfos, pluginMethodsForClasses, pluginConfigChanged, _cntlr, _pluginBase
@@ -94,8 +98,8 @@ def reset() -> None:  # force reloading modules and plugin infos
     if pluginMethodsForClasses:
         pluginMethodsForClasses.clear() # dict by class of list of ordered callable function objects
 
-def orderedPluginConfig():
-    fieldOrder = [
+def orderedPluginConfig() -> dict[str, Any]:
+    fieldOrder: list[TypeModuleInfoKey] = [
         'name',
         'status',
         'fileDate',
@@ -111,7 +115,7 @@ def orderedPluginConfig():
     ]
     priorityIndex = {k: i for i, k in enumerate(fieldOrder)}
 
-    def sortModuleInfo(moduleInfo):
+    def sortModuleInfo(moduleInfo: dict[TypeModuleInfoKey, Any]) -> dict[TypeModuleInfoKey, Any]:
         # Prioritize known fields by the index in fieldOrder; sort others alphabetically
         orderedKeys = sorted(
             moduleInfo.keys(),
@@ -321,7 +325,7 @@ def getModuleFilename(moduleURL: str, reload: bool, normalize: bool, base: str |
     return None, None
 
 
-def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint | None) -> dict | None:
+def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint | None) -> dict[TypeModuleInfoKey, Any] | None:
     moduleDir, moduleName = os.path.split(moduleFilename)
     with arelle.FileSource.openFileStream(_cntlr, moduleFilename) as f:
         contents = f.read()
@@ -332,7 +336,7 @@ def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint 
     functionDefNames = set()
     methodDefNamesByClass = defaultdict(set)
     moduleImports = []
-    moduleInfo = {"name":None}
+    moduleInfo: dict[TypeModuleInfoKey, Any] = {"name":None}
     isPlugin = False
     for item in tree.body:
         if isinstance(item, ast.Assign):
@@ -426,7 +430,7 @@ def moduleModuleInfo(
         moduleURL: str | None = None,
         entryPoint: EntryPoint | None = None,
         reload: bool = False,
-        parentImportsSubtree: bool = False) -> dict | None:
+        parentImportsSubtree: bool = False) -> dict[TypeModuleInfoKey, Any] | None:
     """
     Generates a module info dict based on the provided `moduleURL` or `entryPoint`
     Exactly one of "moduleURL" or "entryPoint" must be provided, otherwise a RuntimeError will be thrown.
@@ -579,7 +583,7 @@ def _find_and_load_module(moduleDir: str, moduleName: str) -> ModuleType | None:
 
     return sys.modules[moduleName]
 
-def loadModule(moduleInfo: dict[str, Any], packagePrefix: str="") -> None:
+def loadModule(moduleInfo: dict[TypeModuleInfoKey, Any], packagePrefix: str="") -> None:
     name = moduleInfo['name']
     moduleURL = moduleInfo['moduleURL']
     modulePath = Path(moduleInfo['path'])
@@ -667,7 +671,7 @@ def pluginClassMethods(className: str) -> Iterator[Callable[..., Any]]:
         yield from pluginMethodsForClass
 
 
-def addPluginModule(name: str) -> dict[str, Any] | None:
+def addPluginModule(name: str) -> dict[TypeModuleInfoKey, Any] | None:
     """
     Discover plugin entry points with given name.
     :param name: The name to search for
@@ -695,7 +699,7 @@ def reloadPluginModule(name):
 def removePluginModule(name):
     moduleInfo = pluginConfig["modules"].get(name)
     if moduleInfo and name:
-        def _removePluginModule(moduleInfo):
+        def _removePluginModule(moduleInfo: dict[TypeModuleInfoKey, Any]) -> None:
             _name = moduleInfo.get("name")
             if _name:
                 for classMethod in moduleInfo["classMethods"]:
@@ -714,7 +718,7 @@ def removePluginModule(name):
     return False # unable to remove
 
 
-def addPluginModuleInfo(plugin_module_info: dict[str, Any]) -> dict[str, Any] | None:
+def addPluginModuleInfo(plugin_module_info: dict[TypeModuleInfoKey, Any] | None) -> dict[TypeModuleInfoKey, Any] | None:
     """
     Given a dictionary containing module information, loads plugin info into `pluginConfig`
     :param plugin_module_info: Dictionary of module info fields. See comment block in PluginManager.py for structure.
@@ -725,7 +729,7 @@ def addPluginModuleInfo(plugin_module_info: dict[str, Any]) -> dict[str, Any] | 
     name = plugin_module_info["name"]
     removePluginModule(name)  # remove any prior entry for this module
 
-    def _addPluginSubModule(subModuleInfo: dict[str, Any]):
+    def _addPluginSubModule(subModuleInfo: dict[TypeModuleInfoKey, Any]) -> None:
         """
         Inline function for recursively exploring module imports
         :param subModuleInfo: Module information to add.
@@ -764,9 +768,9 @@ class EntryPointRef:
     aliases: set[str]
     entryPoint: EntryPoint | None
     moduleFilename: str | None
-    moduleInfo: dict | None
+    moduleInfo: dict[TypeModuleInfoKey, Any] | None
 
-    def createModuleInfo(self) -> dict | None:
+    def createModuleInfo(self) -> dict[TypeModuleInfoKey, Any] | None:
         """
         Creates a module information dictionary from the entry point ref.
         :return: A module inforomation dictionary
@@ -802,7 +806,7 @@ class EntryPointRef:
         aliases = set()
         if entryPoint:
             aliases.add(entryPoint.name)
-        moduleInfo: dict | None = None
+        moduleInfo: dict[TypeModuleInfoKey, Any] | None = None
         if moduleFilename:
             moduleInfo = parsePluginInfo(moduleFilename, moduleFilename, entryPoint)
             if moduleInfo is None:

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -42,12 +42,18 @@ PLUGIN_TRACE_LEVEL = logging.WARNING
 
 # plugin control is static to correspond to statically loaded modules
 pluginJsonFile = None
-pluginConfig: dict | None = None
+# The code in this module mostly assumes these values are not `NoneType` and
+# relies on try/except catching AttributeError, TypeError, etc. if they ever are.
+# Rather than add type casting or assertions throughout the code, we will ignore
+# the assignment type hint error here and rely on the initialization process to set
+# these values before use.
+pluginConfig: dict[str, Any] = None # type: ignore[assignment]
+_cntlr: Cntlr = None # type: ignore[assignment]
+
 pluginConfigChanged = False
 pluginTraceFileLogger = None
 modulePluginInfos = {}
 pluginMethodsForClasses = {}
-_cntlr = None
 _pluginBase = None
 EMPTYLIST = []
 _ERROR_MESSAGE_IMPORT_TEMPLATE = "Unable to load module {}"

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -206,6 +206,10 @@ def modulesWithNewerFileDates():
     names = set()
     for moduleName, moduleInfo in pluginConfig["modules"].items():
         freshenedFilename = _cntlr.webCache.getfilename(moduleInfo["moduleURL"], checkModifiedTime=True, normalize=True, base=_pluginBase)
+        if freshenedFilename is None:
+            _msg = _("Module URL could not be mapped to a filepath: {moduleURL}").format(moduleURL=moduleInfo["moduleURL"])
+            logPluginTrace(_msg, logging.ERROR)
+            continue
         try:
             if os.path.isdir(freshenedFilename): # if freshenedFilename is a directory containing an __init__.py file, open that instead
                 if os.path.isfile(os.path.join(freshenedFilename, "__init__.py")):
@@ -231,6 +235,10 @@ def freshenModuleInfos():
     for moduleName, moduleInfo in pluginConfig["modules"].items():
         moduleEnabled = moduleInfo["status"] == "enabled"
         freshenedFilename = _cntlr.webCache.getfilename(moduleInfo["moduleURL"], checkModifiedTime=True, normalize=True, base=_pluginBase)
+        if freshenedFilename is None:
+            _msg = _("Module URL could not be mapped to a filepath: {moduleURL}").format(moduleURL=moduleInfo["moduleURL"])
+            logPluginTrace(_msg, logging.ERROR)
+            continue
         try: # check if moduleInfo cached may differ from referenced moduleInfo
             if os.path.isdir(freshenedFilename): # if freshenedFilename is a directory containing an __ini__.py file, open that instead
                 if os.path.isfile(os.path.join(freshenedFilename, "__init__.py")):

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -36,7 +36,7 @@ if TYPE_CHECKING:
 
 _: TypeGetText
 
-PLUGIN_TRACE_FILE = None
+PLUGIN_TRACE_FILE: str | None = None
 # PLUGIN_TRACE_FILE = "c:/temp/pluginerr.txt"
 PLUGIN_TRACE_LEVEL = logging.WARNING
 
@@ -52,10 +52,10 @@ _cntlr: Cntlr = None # type: ignore[assignment]
 
 pluginConfigChanged = False
 pluginTraceFileLogger = None
-modulePluginInfos = {}
-pluginMethodsForClasses = {}
+modulePluginInfos: dict[str, Any] = {}
+pluginMethodsForClasses: dict[str, Any] = {}
 _pluginBase = None
-EMPTYLIST = []
+EMPTYLIST: list[Any] = []
 _ERROR_MESSAGE_IMPORT_TEMPLATE = "Unable to load module {}"
 
 def init(cntlr: Cntlr, loadPluginConfig: bool = True) -> None:

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -17,7 +17,7 @@ import types
 from collections import defaultdict
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
-from importlib.metadata import EntryPoint, entry_points
+from importlib.metadata import EntryPoint, entry_points, Distribution
 from numbers import Number
 from pathlib import Path
 from types import ModuleType
@@ -381,14 +381,16 @@ def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint 
                 moduleInfo["status"] = 'enabled'
                 moduleInfo["fileDate"] = time.strftime('%Y-%m-%dT%H:%M:%S UTC', time.gmtime(os.path.getmtime(moduleFilename)))
                 if entryPoint:
+                    distribution =  cast(Distribution, entryPoint.dist) if getattr(entryPoint, 'dist', None) else None
+                    version = distribution.version if distribution else None
                     moduleInfo["moduleURL"] = moduleFilename  # pip-installed plugins need absolute filepath
                     moduleInfo["entryPoint"] = {
                         "module": entryPoint.module,
                         "name": entryPoint.name,
-                        "version": entryPoint.dist.version if hasattr(entryPoint, 'dist') else None,
+                        "version": version,
                     }
                     if not moduleInfo.get("version"):
-                        moduleInfo["version"] = entryPoint.dist.version  # If no explicit version, retrieve from entry point
+                        moduleInfo["version"] = version # If no explicit version, retrieve from entry point
             elif isinstance(item.value, ast.Constant) and isinstance(item.value.value, str):  # possible constant used in plugininfo, such as VERSION
                 for assignmentName in item.targets:
                     constantStrings[assignmentName.id] = item.value.value

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -543,13 +543,12 @@ def moduleModuleInfo(
     return None
 
 
-def moduleInfo(pluginInfo):
-    moduleInfo = {}
-    for name, value in pluginInfo.items():
-        if isinstance(value, str):
-            moduleInfo[name] = value
-        elif isinstance(value, types.FunctionType):
-            moduleInfo.getdefault('classes', []).append(name)
+def moduleInfo(pluginInfo: Any) -> None:
+    """
+    This is an empty function in place for backwards compatability.
+    Will be removed in future release.
+    """
+    pass
 
 
 def _isAbsoluteModuleURL(moduleURL: str) -> bool:

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -149,8 +149,6 @@ def close() -> None:  # close all loaded methods
         modulePluginInfos.clear()
     if pluginMethodsForClasses is not None:
         pluginMethodsForClasses.clear()
-    global webCache
-    webCache = None
 
 ''' pluginInfo structure:
 

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -189,7 +189,7 @@ moduleInfo = {
 
 '''
 
-def logPluginTrace(message: str, level: Number) -> None:
+def logPluginTrace(message: str, level: int) -> None:
     """
     If plugin trace file logging is configured, logs `message` to it.
     Only logs to controller logger if log is an error.
@@ -202,7 +202,7 @@ def logPluginTrace(message: str, level: Number) -> None:
         _cntlr.addToLog(message=message, level=level, messageCode='arelle:pluginLoadingError')
 
 
-def modulesWithNewerFileDates():
+def modulesWithNewerFileDates() -> set[str]:
     names = set()
     for moduleName, moduleInfo in pluginConfig["modules"].items():
         freshenedFilename = _cntlr.webCache.getfilename(moduleInfo["moduleURL"], checkModifiedTime=True, normalize=True, base=_pluginBase)
@@ -229,7 +229,7 @@ def modulesWithNewerFileDates():
 
     return names
 
-def freshenModuleInfos():
+def freshenModuleInfos() -> None:
     # for modules with different date-times, re-load module info
     missingEnabledModules = []
     for moduleName, moduleInfo in pluginConfig["modules"].items():
@@ -555,7 +555,7 @@ def _isAbsoluteModuleURL(moduleURL: str) -> bool:
     return isAbsolute(moduleURL) or isLegacyAbs(moduleURL)
 
 
-def _get_name_dir_prefix(modulePath: Path, packagePrefix: str = "") -> tuple[str, str, str] | tuple[None, None, None]:
+def _get_name_dir_prefix(modulePath: Path, packagePrefix: str = "") -> tuple[str | None, str | None, str | None]:
     """Get the name, directory and prefix of a module."""
     moduleName = None
     moduleDir = None
@@ -576,7 +576,7 @@ def _get_name_dir_prefix(modulePath: Path, packagePrefix: str = "") -> tuple[str
 
     return (moduleName, moduleDir, packageImportPrefix)
 
-def _get_location(moduleDir: str, moduleName: str) -> str:
+def _get_location(moduleDir: str, moduleName: str) -> Path:
     """Get the file name of a plugin."""
     module_name_path = Path(f"{moduleDir}/{moduleName}.py")
     if os.path.isfile(module_name_path):
@@ -584,7 +584,7 @@ def _get_location(moduleDir: str, moduleName: str) -> str:
 
     return Path(f"{moduleDir}/{moduleName}/__init__.py")
 
-def _find_and_load_module(moduleDir: str, moduleName: str) -> ModuleType | None:
+def _find_and_load_module(moduleDir: str, moduleName: str) -> ModuleType:
     """Load a module based on name and directory."""
     location = _get_location(moduleDir=moduleDir, moduleName=moduleName)
     spec = importlib.util.spec_from_file_location(name=moduleName, location=location)
@@ -707,7 +707,7 @@ def addPluginModule(name: str) -> dict[TypeModuleInfoKey, Any] | None:
     return addPluginModuleInfo(pluginModuleInfo)
 
 
-def reloadPluginModule(name):
+def reloadPluginModule(name: str) -> bool:
     if name in pluginConfig["modules"]:
         url = pluginConfig["modules"][name].get("moduleURL")
         if url:
@@ -717,7 +717,7 @@ def reloadPluginModule(name):
                 return True
     return False
 
-def removePluginModule(name):
+def removePluginModule(name: str) -> bool:
     moduleInfo = pluginConfig["modules"].get(name)
     if moduleInfo and name:
         def _removePluginModule(moduleInfo: dict[TypeModuleInfoKey, Any]) -> None:
@@ -852,7 +852,7 @@ class EntryPointRef:
         global _entryPointRefCache
         if _entryPointRefCache is None:
             assert _pluginBase is not None
-            _entryPointRefCache = EntryPointRef._discoverBuiltIn([], cast(str, _pluginBase)) + EntryPointRef._discoverInstalled()
+            _entryPointRefCache = EntryPointRef._discoverBuiltIn([], _pluginBase) + EntryPointRef._discoverInstalled()
         return _entryPointRefCache
 
     @staticmethod
@@ -906,7 +906,9 @@ class EntryPointRef:
         :return: Matching entry point ref, if found.
         """
         entryPointRefs = EntryPointRef.search(search)
-        if len(entryPointRefs) == 0:
+        if entryPointRefs is None:
+            return None
+        elif len(entryPointRefs) == 0:
             return None
         elif len(entryPointRefs) > 1:
             paths = [r.moduleFilename for r in entryPointRefs]

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -338,16 +338,17 @@ def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint 
         if '__pluginInfo__' not in contents:
             return None
         tree = ast.parse(contents, filename=moduleFilename)
-    constantStrings = {}
+    constantStrings: dict[str, Any] = {}
     functionDefNames = set()
-    methodDefNamesByClass = defaultdict(set)
+    methodDefNamesByClass: dict[str, set[str]] = defaultdict(set)
     moduleImports = []
     moduleInfo: dict[TypeModuleInfoKey, Any] = {"name":None}
     isPlugin = False
     for item in tree.body:
         if isinstance(item, ast.Assign):
             try:
-                attr = item.targets[0].id
+                _name = cast(ast.Name, item.targets[0])
+                attr = _name.id
             except AttributeError:
                 # Not plugininfo
                 continue
@@ -355,28 +356,37 @@ def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint 
                 isPlugin = True
                 classMethods = []
                 importURLs = []
-                for i, key in enumerate(item.value.keys):
-                    _key = key.value
-                    _value = item.value.values[i]
+                _dict = cast(ast.Dict, item.value)
+                for i, key in enumerate(_dict.keys):
+                    _key = cast(ast.Constant, key).value
+                    if _key is None:
+                        continue
+
+                    _value = _dict.values[i]
+
                     _valueType = _value.__class__.__name__
                     if _key == "import":
                         if _valueType == 'Constant':
-                            importURLs.append(_value.value)
+                            importURLs.append(cast(ast.Constant, _value).value)
                         elif _valueType in ("List", "Tuple"):
-                            for elt in _value.elts:
-                                importURLs.append(elt.value)
+                            for elt in cast(ast.Tuple | ast.List, key).elts:
+                                importURLs.append(cast(ast.Constant, elt).value)
                     elif _valueType == 'Constant':
-                        moduleInfo[_key] = _value.value
+                        _constantValue = cast(ast.Constant, _value)
+                        moduleInfo[_key] = _constantValue.value
                     elif _valueType == 'Name':
-                        if _value.id in constantStrings:
-                            moduleInfo[_key] = constantStrings[_value.id]
-                        elif _value.id in functionDefNames:
+                        _nameValue = cast(ast.Name, _value)
+                        if _nameValue.id in constantStrings:
+                            moduleInfo[_key] = constantStrings[_nameValue.id]
+                        elif _nameValue.id in functionDefNames:
                             classMethods.append(_key)
                     elif _valueType == 'Attribute':
-                        if _value.attr in methodDefNamesByClass[_value.value.id]:
+                        _attributeValue = cast(ast.Attribute, _value)
+                        if _attributeValue.attr in methodDefNamesByClass[cast(ast.Name, _attributeValue.value).id]:
                             classMethods.append(_key)
                     elif _valueType in ("List", "Tuple"):
-                        values = [elt.value for elt in _value.elts]
+                        _listValue = cast(ast.Tuple | ast.List, _value)
+                        values = [cast(ast.Constant, elt).value for elt in _listValue.elts]
                         if _key == "imports":
                             importURLs = values
                         else:
@@ -401,7 +411,7 @@ def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint 
                         moduleInfo["version"] = version # If no explicit version, retrieve from entry point
             elif isinstance(item.value, ast.Constant) and isinstance(item.value.value, str):  # possible constant used in plugininfo, such as VERSION
                 for assignmentName in item.targets:
-                    constantStrings[assignmentName.id] = item.value.value
+                    constantStrings[cast(ast.Name, assignmentName).id] = item.value.value
         elif isinstance(item, ast.ImportFrom):
             if item.level == 1: # starts with .
                 if item.module is None:  # from . import module1, module2, ...

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -612,13 +612,15 @@ def loadModule(moduleInfo: dict[TypeModuleInfoKey, Any], packagePrefix: str="") 
         _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
     else:
         try:
+            if moduleDir is None or moduleName is None:
+                raise ModuleNotFoundError("Unable to load module")
             module = _find_and_load_module(moduleDir=moduleDir, moduleName=moduleName)
             pluginInfo = module.__pluginInfo__.copy()
             elementSubstitutionClasses = None
             if name == pluginInfo.get('name'):
                 pluginInfo["moduleURL"] = moduleURL
                 modulePluginInfos[name] = pluginInfo
-                if 'localeURL' in pluginInfo:
+                if 'localeURL' in pluginInfo and module.__file__ is not None:
                     # set L10N internationalization in loaded module
                     localeDir = os.path.dirname(module.__file__) + os.sep + pluginInfo['localeURL']
                     try:

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -463,6 +463,7 @@ def moduleModuleInfo(
         # If entry point is provided, use it to retrieve `moduleFilename`
         moduleFilename = moduleURL = entryPoint.load()()
     else:
+        assert moduleURL is not None
         # Otherwise, we will verify the path before continuing
         moduleFilename, entryPoint = getModuleFilename(moduleURL, reload=reload, normalize=True, base=_pluginBase)
 

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -652,8 +652,9 @@ def loadModule(moduleInfo: dict[TypeModuleInfoKey, Any], packagePrefix: str="") 
                     _msg = _("Exception loading plug-in {name}: processing ModelObjectFactory.ElementSubstitutionClasses").format(
                             name=name, error=err)
                     logPluginTrace(_msg, logging.ERROR)
-            for importModuleInfo in moduleInfo.get('imports', EMPTYLIST):
-                loadModule(importModuleInfo, packageImportPrefix)
+            if packageImportPrefix is not None:
+                for importModuleInfo in moduleInfo.get('imports', EMPTYLIST):
+                    loadModule(importModuleInfo, packageImportPrefix)
         except (AttributeError, ImportError, FileNotFoundError, ModuleNotFoundError, TypeError, SystemError) as err:
             # Send a summary of the error to the logger and retain the stacktrace for stderr
             _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -62,717 +62,727 @@ TypeModuleInfoKey = Union[
     str, bytes, int, float, complex, types.EllipsisType, None
 ]
 
-def init(cntlr: Cntlr, loadPluginConfig: bool = True) -> None:
-    global pluginJsonFile, pluginConfig, pluginTraceFileLogger, modulePluginInfos, pluginMethodsForClasses, pluginConfigChanged, _cntlr, _pluginBase
-    if PLUGIN_TRACE_FILE:
-        pluginTraceFileLogger = logging.getLogger(__name__)
-        pluginTraceFileLogger.propagate = False
-        handler = logging.FileHandler(PLUGIN_TRACE_FILE)
-        formatter = logging.Formatter('%(asctime)s.%(msecs)03dz [%(levelname)s] %(message)s', datefmt='%Y-%m-%dT%H:%M:%S')
-        handler.setFormatter(formatter)
-        handler.setLevel(PLUGIN_TRACE_LEVEL)
-        pluginTraceFileLogger.addHandler(handler)
-    pluginConfigChanged = False
-    _cntlr = cntlr
-    _pluginBase = cntlr.pluginDir + os.sep
-    if loadPluginConfig:
-        try:
-            pluginJsonFile = cntlr.userAppDir + os.sep + "plugins.json"
-            with open(pluginJsonFile, encoding='utf-8') as f:
-                pluginConfig = json.load(f)
-            freshenModuleInfos()
-        except Exception:
-            pass # on GAE no userAppDir, will always come here
-    if not pluginConfig:
-        pluginConfig = {  # savable/reloadable plug in configuration
-            "modules": {}, # dict of moduleInfos by module name
-            "classes": {}  # dict by class name of list of class modules in execution order
-        }
-        pluginConfigChanged = False # don't save until something is added to pluginConfig
-    modulePluginInfos = {}  # dict of loaded module pluginInfo objects by module names
-    pluginMethodsForClasses = {} # dict by class of list of ordered callable function objects
 
-def reset() -> None:  # force reloading modules and plugin infos
-    if modulePluginInfos:
-        modulePluginInfos.clear()  # dict of loaded module pluginInfo objects by module names
-    if pluginMethodsForClasses:
-        pluginMethodsForClasses.clear() # dict by class of list of ordered callable function objects
+class PluginManager:
 
-def orderedPluginConfig() -> dict[str, Any]:
-    fieldOrder: list[TypeModuleInfoKey] = [
-        'name',
-        'status',
-        'fileDate',
-        'version',
-        'description',
-        'moduleURL',
-        'localeURL',
-        'localeDomain',
-        'license',
-        'author',
-        'copyright',
-        'classMethods',
-    ]
-    priorityIndex = {k: i for i, k in enumerate(fieldOrder)}
-
-    def sortModuleInfo(moduleInfo: dict[TypeModuleInfoKey, Any]) -> dict[TypeModuleInfoKey, Any]:
-        # Prioritize known fields by the index in fieldOrder; sort others alphabetically
-        orderedKeys = sorted(
-            moduleInfo.keys(),
-            key=lambda k: (priorityIndex.get(k, len(priorityIndex)), k)
-        )
-        return {k: moduleInfo[k] for k in orderedKeys}
-
-    orderedModules = {
-        moduleName: sortModuleInfo(pluginConfig['modules'][moduleName])
-        for moduleName in sorted(pluginConfig['modules'].keys())
-    }
-
-    return {
-        'modules': orderedModules,
-        'classes': dict(sorted(pluginConfig['classes'].items()))
-    }
-
-def save(cntlr: Cntlr) -> None:
-    global pluginConfigChanged
-    if pluginConfigChanged and cntlr.hasFileSystem and not cntlr.disablePersistentConfig:
-        pluginJsonFile = cntlr.userAppDir + os.sep + "plugins.json"
-        with open(pluginJsonFile, 'w', encoding='utf-8') as f:
-            jsonStr = str(json.dumps(orderedPluginConfig(), ensure_ascii=False, indent=2)) # might not be unicode in 2.7
-            f.write(jsonStr)
+    def __init__(self, cntlr: Cntlr, loadPluginConfig: bool = True) -> None:
+        global pluginJsonFile, pluginConfig, pluginTraceFileLogger, modulePluginInfos, pluginMethodsForClasses, pluginConfigChanged, _cntlr, _pluginBase
+        if PLUGIN_TRACE_FILE:
+            pluginTraceFileLogger = logging.getLogger(__name__)
+            pluginTraceFileLogger.propagate = False
+            handler = logging.FileHandler(PLUGIN_TRACE_FILE)
+            formatter = logging.Formatter('%(asctime)s.%(msecs)03dz [%(levelname)s] %(message)s', datefmt='%Y-%m-%dT%H:%M:%S')
+            handler.setFormatter(formatter)
+            handler.setLevel(PLUGIN_TRACE_LEVEL)
+            pluginTraceFileLogger.addHandler(handler)
         pluginConfigChanged = False
-
-def close() -> None:  # close all loaded methods
-    if pluginConfig is not None:
-        pluginConfig.clear()
-    if modulePluginInfos is not None:
-        modulePluginInfos.clear()
-    if pluginMethodsForClasses is not None:
-        pluginMethodsForClasses.clear()
-
-''' pluginInfo structure:
-
-__pluginInfo__ = {
-    'name': (required)
-    'version': (required)
-    'description': (optional)
-    'moduleURL': (required) # added by plug in manager, not in source file
-    'localeURL': (optional) # L10N internationalization for this module (subdirectory if relative)
-    'localeDomain': (optional) # domain for L10N internationalization (e.g., 'arelle')
-    'license': (optional)
-    'author': (optional)
-    'copyright': (optional)
-    # classes of mount points (required)
-    'a.b.c': method (function) to do something
-    'a.b.c.d' : method (function) to do something
-    # import (plugins to be loaded for this package) (may be multiple imports like in python)
-    'import': [string, list or tuple of URLs or relative file names of imported plug-ins]
-}
-
-moduleInfo = {
-    'name': (required)
-    'status': enabled | disabled
-    'version': (required)
-    'fileDate': 2000-01-01
-    'description': (optional)
-    'moduleURL': (required) # same as file path, can be a URL (of a non-package .py file or a package directory)
-    'localeURL': (optional) # for L10N internationalization within module
-    'localeDomain': (optional) # domain for L10N internationalization
-    'license': (optional)
-    'author': (optional)
-    'copyright': (optional)
-    'classMethods': [list of class names that have methods in module]
-    'imports': [list of imported plug-in moduleInfos]
-    'isImported': True if module was imported by a parent plug-in module
-}
-
-
-'''
-
-def logPluginTrace(message: str, level: int) -> None:
-    """
-    If plugin trace file logging is configured, logs `message` to it.
-    Only logs to controller logger if log is an error.
-    :param message: Message to be logged
-    :param level: Log level of message (e.g. logging.INFO)
-    """
-    if pluginTraceFileLogger:
-        pluginTraceFileLogger.log(level, message)
-    if level >= logging.ERROR:
-        _cntlr.addToLog(message=message, level=level, messageCode='arelle:pluginLoadingError')
-
-
-def modulesWithNewerFileDates() -> set[str]:
-    names = set()
-    for moduleName, moduleInfo in pluginConfig["modules"].items():
-        freshenedFilename = _cntlr.webCache.getfilename(moduleInfo["moduleURL"], checkModifiedTime=True, normalize=True, base=_pluginBase)
-        if freshenedFilename is None:
-            _msg = _("Module URL could not be mapped to a filepath: {moduleURL}").format(moduleURL=moduleInfo["moduleURL"])
-            logPluginTrace(_msg, logging.ERROR)
-            continue
-        try:
-            if os.path.isdir(freshenedFilename): # if freshenedFilename is a directory containing an __init__.py file, open that instead
-                if os.path.isfile(os.path.join(freshenedFilename, "__init__.py")):
-                    freshenedFilename = os.path.join(freshenedFilename, "__init__.py")
-            elif not freshenedFilename.endswith(".py") and not os.path.exists(freshenedFilename) and os.path.exists(freshenedFilename + ".py"):
-                freshenedFilename += ".py" # extension module without .py suffix
-            if os.path.exists(freshenedFilename):
-                if moduleInfo["fileDate"] < time.strftime('%Y-%m-%dT%H:%M:%S UTC', time.gmtime(os.path.getmtime(freshenedFilename))):
-                    names.add(moduleInfo["name"])
-            else:
-                _msg = _("File not found for '{name}' plug-in when checking for updated module info. Path: '{path}'") \
-                    .format(name=moduleName, path=freshenedFilename)
-                logPluginTrace(_msg, logging.ERROR)
-        except Exception as err:
-            _msg = _("Exception at plug-in method modulesWithNewerFileDates: {error}").format(error=err)
-            logPluginTrace(_msg, logging.ERROR)
-
-    return names
-
-def freshenModuleInfos() -> None:
-    # for modules with different date-times, re-load module info
-    missingEnabledModules = []
-    for moduleName, moduleInfo in pluginConfig["modules"].items():
-        moduleEnabled = moduleInfo["status"] == "enabled"
-        freshenedFilename = _cntlr.webCache.getfilename(moduleInfo["moduleURL"], checkModifiedTime=True, normalize=True, base=_pluginBase)
-        if freshenedFilename is None:
-            _msg = _("Module URL could not be mapped to a filepath: {moduleURL}").format(moduleURL=moduleInfo["moduleURL"])
-            logPluginTrace(_msg, logging.ERROR)
-            continue
-        try: # check if moduleInfo cached may differ from referenced moduleInfo
-            if os.path.isdir(freshenedFilename): # if freshenedFilename is a directory containing an __ini__.py file, open that instead
-                if os.path.isfile(os.path.join(freshenedFilename, "__init__.py")):
-                    freshenedFilename = os.path.join(freshenedFilename, "__init__.py")
-            elif not freshenedFilename.endswith(".py") and not os.path.exists(freshenedFilename) and os.path.exists(freshenedFilename + ".py"):
-                freshenedFilename += ".py" # extension module without .py suffix
-            if os.path.exists(freshenedFilename):
-                if moduleInfo["fileDate"] != time.strftime('%Y-%m-%dT%H:%M:%S UTC', time.gmtime(os.path.getmtime(freshenedFilename))):
-                    freshenedModuleInfo = moduleModuleInfo(moduleURL=moduleInfo["moduleURL"], reload=True)
-                    if freshenedModuleInfo is not None:
-                        if freshenedModuleInfo["name"] == moduleName:
-                            pluginConfig["modules"][moduleName] = freshenedModuleInfo
-                        else:
-                            # Module has been re-named
-                            if moduleEnabled:
-                                missingEnabledModules.append(moduleName)
-            # User can avoid pruning by disabling plugin
-            elif moduleEnabled:
-                missingEnabledModules.append(moduleName)
-            else:
-                _msg = _("File not found for '{name}' plug-in when attempting to update module info. Path: '{path}'")\
-                    .format(name=moduleName, path=freshenedFilename)
-                logPluginTrace(_msg, logging.ERROR)
-        except Exception as err:
-            _msg = _("Exception at plug-in method freshenModuleInfos: {error}").format(error=err)
-            logPluginTrace(_msg, logging.ERROR)
-    for moduleName in missingEnabledModules:
-        removePluginModule(moduleName)
-        # Try re-adding plugin modules by name (for plugins that moved from built-in to pip installed)
-        moduleInfo = addPluginModule(moduleName)
-        if moduleInfo:
-            pluginConfig["modules"][moduleInfo["name"]] = moduleInfo
-            loadModule(moduleInfo)
-            logPluginTrace(_("Reloaded plugin that failed loading: {} {}").format(moduleName, moduleInfo), logging.INFO)
-        else:
-            logPluginTrace(_("Removed plugin that failed loading (plugin may have been archived): {}").format(moduleName), logging.ERROR)
-    save(_cntlr)
-
-
-def normalizeModuleFilename(moduleFilename: str) -> str | None:
-    """
-    Attempts to find python script as plugin entry point.
-    A value will be returned
-      if `moduleFilename` exists as-is,
-      if `moduleFilename` is a directory containing __init__.py, or
-      if `moduleFilename` with .py extension added exists
-    :param moduleFilename:
-    :return: Normalized filename, if exists
-    """
-    if os.path.isfile(moduleFilename):
-        # moduleFilename exists as-is, use it
-        return moduleFilename
-    if os.path.isdir(moduleFilename):
-        # moduleFilename is a directory, only valid script is __init__.py contained inside
-        initPath = os.path.join(moduleFilename, "__init__.py")
-        if os.path.isfile(initPath):
-            return initPath
-        else:
-            return None
-    if not moduleFilename.endswith(".py"):
-        # moduleFilename is not a file or directory, try adding .py
-        pyPath = moduleFilename + ".py"
-        if os.path.exists(pyPath):
-            return pyPath
-    return None
-
-
-def getModuleFilename(moduleURL: str, reload: bool, normalize: bool, base: str | None) -> tuple[str | None, EntryPoint | None]:
-    #TODO several directories, eg User Application Data
-    moduleFilename = _cntlr.webCache.getfilename(moduleURL, reload=reload, normalize=normalize, base=base)
-    if moduleFilename:
-        # `moduleURL` was mapped to a local filepath
-        moduleFilename = normalizeModuleFilename(moduleFilename)
-        if moduleFilename:
-            # `moduleFilename` normalized to an existing script
-            return moduleFilename, None
-    if base and not _isAbsoluteModuleURL(moduleURL):
-        # Search for a matching plugin deeper in the plugin directory tree.
-        # Handles cases where a plugin exists in a nested structure, such as
-        # when a developer clones an entire repository into the plugin directory.
-        # Example: arelle/plugin/xule/plugin/xule/__init__.py
-        for path in glob("**/" + moduleURL.replace('\\', '/'), recursive=True):
-            if normalizedPath := normalizeModuleFilename(path):
-                return normalizedPath, None
-    # `moduleFilename` did not map to a local filepath or did not normalize to a script
-    # Try using `moduleURL` to search for pip-installed entry point
-    entryPointRef = EntryPointRef.get(moduleURL)
-    if entryPointRef is not None:
-        return entryPointRef.moduleFilename, entryPointRef.entryPoint
-    return None, None
-
-
-def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint | None) -> dict[TypeModuleInfoKey, Any] | None:
-    moduleDir, moduleName = os.path.split(moduleFilename)
-    with arelle.FileSource.openFileStream(_cntlr, moduleFilename) as f:
-        contents = f.read()
-        if '__pluginInfo__' not in contents:
-            return None
-        tree = ast.parse(contents, filename=moduleFilename)
-    constantStrings: dict[str, Any] = {}
-    functionDefNames = set()
-    methodDefNamesByClass: dict[str, set[str]] = defaultdict(set)
-    moduleImports = []
-    moduleInfo: dict[TypeModuleInfoKey, Any] = {"name":None}
-    isPlugin = False
-    for item in tree.body:
-        if isinstance(item, ast.Assign):
+        _cntlr = cntlr
+        _pluginBase = cntlr.pluginDir + os.sep
+        if loadPluginConfig:
             try:
-                _name = cast(ast.Name, item.targets[0])
-                attr = _name.id
-            except AttributeError:
-                # Not plugininfo
+                pluginJsonFile = cntlr.userAppDir + os.sep + "plugins.json"
+                with open(pluginJsonFile, encoding='utf-8') as f:
+                    pluginConfig = json.load(f)
+                self.freshenModuleInfos()
+            except Exception:
+                pass # on GAE no userAppDir, will always come here
+        if not pluginConfig:
+            pluginConfig = {  # savable/reloadable plug in configuration
+                "modules": {}, # dict of moduleInfos by module name
+                "classes": {}  # dict by class name of list of class modules in execution order
+            }
+            pluginConfigChanged = False # don't save until something is added to pluginConfig
+        modulePluginInfos = {}  # dict of loaded module pluginInfo objects by module names
+        pluginMethodsForClasses = {} # dict by class of list of ordered callable function objects
+
+    def reset(self) -> None:  # force reloading modules and plugin infos
+        if modulePluginInfos:
+            modulePluginInfos.clear()  # dict of loaded module pluginInfo objects by module names
+        if pluginMethodsForClasses:
+            pluginMethodsForClasses.clear() # dict by class of list of ordered callable function objects
+
+    def orderedPluginConfig(self) -> dict[str, Any]:
+        fieldOrder: list[TypeModuleInfoKey] = [
+            'name',
+            'status',
+            'fileDate',
+            'version',
+            'description',
+            'moduleURL',
+            'localeURL',
+            'localeDomain',
+            'license',
+            'author',
+            'copyright',
+            'classMethods',
+        ]
+        priorityIndex = {k: i for i, k in enumerate(fieldOrder)}
+
+        def sortModuleInfo(moduleInfo: dict[TypeModuleInfoKey, Any]) -> dict[TypeModuleInfoKey, Any]:
+            # Prioritize known fields by the index in fieldOrder; sort others alphabetically
+            orderedKeys = sorted(
+                moduleInfo.keys(),
+                key=lambda k: (priorityIndex.get(k, len(priorityIndex)), k)
+            )
+            return {k: moduleInfo[k] for k in orderedKeys}
+
+        orderedModules = {
+            moduleName: sortModuleInfo(pluginConfig['modules'][moduleName])
+            for moduleName in sorted(pluginConfig['modules'].keys())
+        }
+
+        return {
+            'modules': orderedModules,
+            'classes': dict(sorted(pluginConfig['classes'].items()))
+        }
+
+    def save(self, cntlr: Cntlr) -> None:
+        global pluginConfigChanged
+        if pluginConfigChanged and cntlr.hasFileSystem and not cntlr.disablePersistentConfig:
+            pluginJsonFile = cntlr.userAppDir + os.sep + "plugins.json"
+            with open(pluginJsonFile, 'w', encoding='utf-8') as f:
+                jsonStr = str(json.dumps(self.orderedPluginConfig(), ensure_ascii=False, indent=2)) # might not be unicode in 2.7
+                f.write(jsonStr)
+            pluginConfigChanged = False
+
+    def close(self) -> None:  # close all loaded methods
+        if pluginConfig is not None:
+            pluginConfig.clear()
+        if modulePluginInfos is not None:
+            modulePluginInfos.clear()
+        if pluginMethodsForClasses is not None:
+            pluginMethodsForClasses.clear()
+
+    ''' pluginInfo structure:
+
+    __pluginInfo__ = {
+        'name': (required)
+        'version': (required)
+        'description': (optional)
+        'moduleURL': (required) # added by plug in manager, not in source file
+        'localeURL': (optional) # L10N internationalization for this module (subdirectory if relative)
+        'localeDomain': (optional) # domain for L10N internationalization (e.g., 'arelle')
+        'license': (optional)
+        'author': (optional)
+        'copyright': (optional)
+        # classes of mount points (required)
+        'a.b.c': method (function) to do something
+        'a.b.c.d' : method (function) to do something
+        # import (plugins to be loaded for this package) (may be multiple imports like in python)
+        'import': [string, list or tuple of URLs or relative file names of imported plug-ins]
+    }
+
+    moduleInfo = {
+        'name': (required)
+        'status': enabled | disabled
+        'version': (required)
+        'fileDate': 2000-01-01
+        'description': (optional)
+        'moduleURL': (required) # same as file path, can be a URL (of a non-package .py file or a package directory)
+        'localeURL': (optional) # for L10N internationalization within module
+        'localeDomain': (optional) # domain for L10N internationalization
+        'license': (optional)
+        'author': (optional)
+        'copyright': (optional)
+        'classMethods': [list of class names that have methods in module]
+        'imports': [list of imported plug-in moduleInfos]
+        'isImported': True if module was imported by a parent plug-in module
+    }
+
+
+    '''
+
+    def logPluginTrace(self, message: str, level: int) -> None:
+        """
+        If plugin trace file logging is configured, logs `message` to it.
+        Only logs to controller logger if log is an error.
+        :param message: Message to be logged
+        :param level: Log level of message (e.g. logging.INFO)
+        """
+        if pluginTraceFileLogger:
+            pluginTraceFileLogger.log(level, message)
+        if level >= logging.ERROR:
+            _cntlr.addToLog(message=message, level=level, messageCode='arelle:pluginLoadingError')
+
+
+    def modulesWithNewerFileDates(self) -> set[str]:
+        names = set()
+        for moduleName, moduleInfo in pluginConfig["modules"].items():
+            freshenedFilename = _cntlr.webCache.getfilename(moduleInfo["moduleURL"], checkModifiedTime=True, normalize=True, base=_pluginBase)
+            if freshenedFilename is None:
+                _msg = _("Module URL could not be mapped to a filepath: {moduleURL}").format(moduleURL=moduleInfo["moduleURL"])
+                self.logPluginTrace(_msg, logging.ERROR)
                 continue
-            if attr == "__pluginInfo__":
-                isPlugin = True
-                classMethods = []
-                importURLs = []
-                _dict = cast(ast.Dict, item.value)
-                for i, key in enumerate(_dict.keys):
-                    _key = cast(ast.Constant, key).value
-                    if _key is None:
-                        continue
-
-                    _value = _dict.values[i]
-
-                    _valueType = _value.__class__.__name__
-                    if _key == "import":
-                        if _valueType == 'Constant':
-                            importURLs.append(cast(ast.Constant, _value).value)
-                        elif _valueType in ("List", "Tuple"):
-                            for elt in cast(ast.Tuple | ast.List, key).elts:
-                                importURLs.append(cast(ast.Constant, elt).value)
-                    elif _valueType == 'Constant':
-                        _constantValue = cast(ast.Constant, _value)
-                        moduleInfo[_key] = _constantValue.value
-                    elif _valueType == 'Name':
-                        _nameValue = cast(ast.Name, _value)
-                        if _nameValue.id in constantStrings:
-                            moduleInfo[_key] = constantStrings[_nameValue.id]
-                        elif _nameValue.id in functionDefNames:
-                            classMethods.append(_key)
-                    elif _valueType == 'Attribute':
-                        _attributeValue = cast(ast.Attribute, _value)
-                        if _attributeValue.attr in methodDefNamesByClass[cast(ast.Name, _attributeValue.value).id]:
-                            classMethods.append(_key)
-                    elif _valueType in ("List", "Tuple"):
-                        _listValue = cast(ast.Tuple | ast.List, _value)
-                        values = [cast(ast.Constant, elt).value for elt in _listValue.elts]
-                        if _key == "imports":
-                            importURLs = values
-                        else:
-                            moduleInfo[_key] = values
-
-                moduleInfo['classMethods'] = classMethods
-                moduleInfo['importURLs'] = importURLs
-                moduleInfo["moduleURL"] = moduleURL
-                moduleInfo["path"] = moduleFilename
-                moduleInfo["status"] = 'enabled'
-                moduleInfo["fileDate"] = time.strftime('%Y-%m-%dT%H:%M:%S UTC', time.gmtime(os.path.getmtime(moduleFilename)))
-                if entryPoint:
-                    distribution =  cast(Distribution, entryPoint.dist) if getattr(entryPoint, 'dist', None) else None
-                    version = distribution.version if distribution else None
-                    moduleInfo["moduleURL"] = moduleFilename  # pip-installed plugins need absolute filepath
-                    moduleInfo["entryPoint"] = {
-                        "module": entryPoint.module,
-                        "name": entryPoint.name,
-                        "version": version,
-                    }
-                    if not moduleInfo.get("version"):
-                        moduleInfo["version"] = version # If no explicit version, retrieve from entry point
-            elif isinstance(item.value, ast.Constant) and isinstance(item.value.value, str):  # possible constant used in plugininfo, such as VERSION
-                for assignmentName in item.targets:
-                    constantStrings[cast(ast.Name, assignmentName).id] = item.value.value
-        elif isinstance(item, ast.ImportFrom):
-            if item.level == 1: # starts with .
-                if item.module is None:  # from . import module1, module2, ...
-                    for importee in item.names:
-                        if importee.name == '*': #import all submodules
-                            for _file in os.listdir(moduleDir):
-                                if _file != moduleName and os.path.isfile(_file) and _file.endswith(".py"):
-                                    moduleImports.append(_file)
-                        elif (os.path.isfile(os.path.join(moduleDir, importee.name + ".py"))
-                              and importee.name not in moduleImports):
-                            moduleImports.append(importee.name)
+            try:
+                if os.path.isdir(freshenedFilename): # if freshenedFilename is a directory containing an __init__.py file, open that instead
+                    if os.path.isfile(os.path.join(freshenedFilename, "__init__.py")):
+                        freshenedFilename = os.path.join(freshenedFilename, "__init__.py")
+                elif not freshenedFilename.endswith(".py") and not os.path.exists(freshenedFilename) and os.path.exists(freshenedFilename + ".py"):
+                    freshenedFilename += ".py" # extension module without .py suffix
+                if os.path.exists(freshenedFilename):
+                    if moduleInfo["fileDate"] < time.strftime('%Y-%m-%dT%H:%M:%S UTC', time.gmtime(os.path.getmtime(freshenedFilename))):
+                        names.add(moduleInfo["name"])
                 else:
-                    modulePkgs = item.module.split('.')
-                    modulePath = os.path.join(*modulePkgs)
-                    if (os.path.isfile(os.path.join(moduleDir, modulePath) + ".py")
-                            and modulePath not in moduleImports):
-                        moduleImports.append(modulePath)
-                    for importee in item.names:
-                        _importeePfxName = os.path.join(modulePath, importee.name)
-                        if (os.path.isfile(os.path.join(moduleDir, _importeePfxName) + ".py")
-                                and _importeePfxName not in moduleImports):
-                            moduleImports.append(_importeePfxName)
-        elif isinstance(item, ast.FunctionDef): # possible functionDef used in plugininfo
-            functionDefNames.add(item.name)
-        elif isinstance(item, ast.ClassDef):  # possible ClassDef used in plugininfo
-            for classItem in item.body:
-                if isinstance(classItem, ast.FunctionDef):
-                    methodDefNamesByClass[item.name].add(classItem.name)
-    moduleInfo["moduleImports"] = moduleImports
-    return moduleInfo if isPlugin else None
+                    _msg = _("File not found for '{name}' plug-in when checking for updated module info. Path: '{path}'") \
+                        .format(name=moduleName, path=freshenedFilename)
+                    self.logPluginTrace(_msg, logging.ERROR)
+            except Exception as err:
+                _msg = _("Exception at plug-in method modulesWithNewerFileDates: {error}").format(error=err)
+                self.logPluginTrace(_msg, logging.ERROR)
+
+        return names
+
+    def freshenModuleInfos(self) -> None:
+        # for modules with different date-times, re-load module info
+        missingEnabledModules = []
+        for moduleName, moduleInfo in pluginConfig["modules"].items():
+            moduleEnabled = moduleInfo["status"] == "enabled"
+            freshenedFilename = _cntlr.webCache.getfilename(moduleInfo["moduleURL"], checkModifiedTime=True, normalize=True, base=_pluginBase)
+            if freshenedFilename is None:
+                _msg = _("Module URL could not be mapped to a filepath: {moduleURL}").format(moduleURL=moduleInfo["moduleURL"])
+                self.logPluginTrace(_msg, logging.ERROR)
+                continue
+            try: # check if moduleInfo cached may differ from referenced moduleInfo
+                if os.path.isdir(freshenedFilename): # if freshenedFilename is a directory containing an __ini__.py file, open that instead
+                    if os.path.isfile(os.path.join(freshenedFilename, "__init__.py")):
+                        freshenedFilename = os.path.join(freshenedFilename, "__init__.py")
+                elif not freshenedFilename.endswith(".py") and not os.path.exists(freshenedFilename) and os.path.exists(freshenedFilename + ".py"):
+                    freshenedFilename += ".py" # extension module without .py suffix
+                if os.path.exists(freshenedFilename):
+                    if moduleInfo["fileDate"] != time.strftime('%Y-%m-%dT%H:%M:%S UTC', time.gmtime(os.path.getmtime(freshenedFilename))):
+                        freshenedModuleInfo = self.moduleModuleInfo(moduleURL=moduleInfo["moduleURL"], reload=True)
+                        if freshenedModuleInfo is not None:
+                            if freshenedModuleInfo["name"] == moduleName:
+                                pluginConfig["modules"][moduleName] = freshenedModuleInfo
+                            else:
+                                # Module has been re-named
+                                if moduleEnabled:
+                                    missingEnabledModules.append(moduleName)
+                # User can avoid pruning by disabling plugin
+                elif moduleEnabled:
+                    missingEnabledModules.append(moduleName)
+                else:
+                    _msg = _("File not found for '{name}' plug-in when attempting to update module info. Path: '{path}'")\
+                        .format(name=moduleName, path=freshenedFilename)
+                    self.logPluginTrace(_msg, logging.ERROR)
+            except Exception as err:
+                _msg = _("Exception at plug-in method freshenModuleInfos: {error}").format(error=err)
+                self.logPluginTrace(_msg, logging.ERROR)
+        for moduleName in missingEnabledModules:
+            self.removePluginModule(moduleName)
+            # Try re-adding plugin modules by name (for plugins that moved from built-in to pip installed)
+            moduleInfo = self.addPluginModule(moduleName)
+            if moduleInfo:
+                pluginConfig["modules"][moduleInfo["name"]] = moduleInfo
+                self.loadModule(moduleInfo)
+                self.logPluginTrace(_("Reloaded plugin that failed loading: {} {}").format(moduleName, moduleInfo), logging.INFO)
+            else:
+                self.logPluginTrace(_("Removed plugin that failed loading (plugin may have been archived): {}").format(moduleName), logging.ERROR)
+        self.save(_cntlr)
 
 
-def moduleModuleInfo(
-        moduleURL: str | None = None,
-        entryPoint: EntryPoint | None = None,
-        reload: bool = False,
-        parentImportsSubtree: bool = False) -> dict[TypeModuleInfoKey, Any] | None:
-    """
-    Generates a module info dict based on the provided `moduleURL` or `entryPoint`
-    Exactly one of "moduleURL" or "entryPoint" must be provided, otherwise a RuntimeError will be thrown.
-
-    When `moduleURL` is provided, it will be treated as a file path and will attempt to be normalized and
-    mapped to an existing plugin based on file location. If `moduleURL` fails to be mapped to an existing
-    plugin on its own, it will instead be used to search for an entry point. If found, this function will
-    proceed as if that entry point was provided for `entryPoint`.
-
-    When `entryPoint` is provided, it's location and other details will be used to generate the module info
-    dictionary.
-
-    :param moduleURL: A URL that loosely maps to the file location of a plugin (may be transformed)
-    :param entryPoint: An `EntryPoint` instance
-    :param reload:
-    :param parentImportsSubtree:
-    :return:s
-    """
-    if (moduleURL is None) == (entryPoint is None):
-        raise RuntimeError('Exactly one of "moduleURL" or "entryPoint" must be provided')
-    if entryPoint:
-        # If entry point is provided, use it to retrieve `moduleFilename`
-        moduleFilename = moduleURL = entryPoint.load()()
-    else:
-        assert moduleURL is not None
-        # Otherwise, we will verify the path before continuing
-        moduleFilename, entryPoint = getModuleFilename(moduleURL, reload=reload, normalize=True, base=_pluginBase)
-
-    if moduleFilename:
-        try:
-            logPluginTrace(f"Scanning module for plug-in info: {moduleFilename}", logging.INFO)
-            moduleInfo = parsePluginInfo(moduleURL, moduleFilename, entryPoint)
-            if moduleInfo is None:
+    @staticmethod
+    def normalizeModuleFilename(moduleFilename: str) -> str | None:
+        """
+        Attempts to find python script as plugin entry point.
+        A value will be returned
+          if `moduleFilename` exists as-is,
+          if `moduleFilename` is a directory containing __init__.py, or
+          if `moduleFilename` with .py extension added exists
+        :param moduleFilename:
+        :return: Normalized filename, if exists
+        """
+        if os.path.isfile(moduleFilename):
+            # moduleFilename exists as-is, use it
+            return moduleFilename
+        if os.path.isdir(moduleFilename):
+            # moduleFilename is a directory, only valid script is __init__.py contained inside
+            initPath = os.path.join(moduleFilename, "__init__.py")
+            if os.path.isfile(initPath):
+                return initPath
+            else:
                 return None
+        if not moduleFilename.endswith(".py"):
+            # moduleFilename is not a file or directory, try adding .py
+            pyPath = moduleFilename + ".py"
+            if os.path.exists(pyPath):
+                return pyPath
+        return None
 
-            moduleDir, moduleName = os.path.split(moduleFilename)
-            importURLs = moduleInfo["importURLs"]
-            del moduleInfo["importURLs"]
-            moduleImports = moduleInfo["moduleImports"]
-            del moduleInfo["moduleImports"]
-            moduleImportsSubtree = False
-            mergedImportURLs = []
 
-            for url in importURLs:
-                if url.startswith("module_import"):
+    def getModuleFilename(self, moduleURL: str, reload: bool, normalize: bool, base: str | None) -> tuple[str | None, EntryPoint | None]:
+        #TODO several directories, eg User Application Data
+        moduleFilename = _cntlr.webCache.getfilename(moduleURL, reload=reload, normalize=normalize, base=base)
+        if moduleFilename:
+            # `moduleURL` was mapped to a local filepath
+            moduleFilename = self.normalizeModuleFilename(moduleFilename)
+            if moduleFilename:
+                # `moduleFilename` normalized to an existing script
+                return moduleFilename, None
+        if base and not self._isAbsoluteModuleURL(moduleURL):
+            # Search for a matching plugin deeper in the plugin directory tree.
+            # Handles cases where a plugin exists in a nested structure, such as
+            # when a developer clones an entire repository into the plugin directory.
+            # Example: arelle/plugin/xule/plugin/xule/__init__.py
+            for path in glob("**/" + moduleURL.replace('\\', '/'), recursive=True):
+                if normalizedPath := self.normalizeModuleFilename(path):
+                    return normalizedPath, None
+        # `moduleFilename` did not map to a local filepath or did not normalize to a script
+        # Try using `moduleURL` to search for pip-installed entry point
+        entryPointRef = EntryPointRef.get(moduleURL)
+        if entryPointRef is not None:
+            return entryPointRef.moduleFilename, entryPointRef.entryPoint
+        return None, None
+
+
+    def parsePluginInfo(self, moduleURL: str, moduleFilename: str, entryPoint: EntryPoint | None) -> dict[TypeModuleInfoKey, Any] | None:
+        moduleDir, moduleName = os.path.split(moduleFilename)
+        with arelle.FileSource.openFileStream(_cntlr, moduleFilename) as f:
+            contents = f.read()
+            if '__pluginInfo__' not in contents:
+                return None
+            tree = ast.parse(contents, filename=moduleFilename)
+        constantStrings: dict[str, Any] = {}
+        functionDefNames = set()
+        methodDefNamesByClass: dict[str, set[str]] = defaultdict(set)
+        moduleImports = []
+        moduleInfo: dict[TypeModuleInfoKey, Any] = {"name":None}
+        isPlugin = False
+        for item in tree.body:
+            if isinstance(item, ast.Assign):
+                try:
+                    _name = cast(ast.Name, item.targets[0])
+                    attr = _name.id
+                except AttributeError:
+                    # Not plugininfo
+                    continue
+                if attr == "__pluginInfo__":
+                    isPlugin = True
+                    classMethods = []
+                    importURLs = []
+                    _dict = cast(ast.Dict, item.value)
+                    for i, key in enumerate(_dict.keys):
+                        _key = cast(ast.Constant, key).value
+                        if _key is None:
+                            continue
+
+                        _value = _dict.values[i]
+
+                        _valueType = _value.__class__.__name__
+                        if _key == "import":
+                            if _valueType == 'Constant':
+                                importURLs.append(cast(ast.Constant, _value).value)
+                            elif _valueType in ("List", "Tuple"):
+                                for elt in cast(ast.Tuple | ast.List, key).elts:
+                                    importURLs.append(cast(ast.Constant, elt).value)
+                        elif _valueType == 'Constant':
+                            _constantValue = cast(ast.Constant, _value)
+                            moduleInfo[_key] = _constantValue.value
+                        elif _valueType == 'Name':
+                            _nameValue = cast(ast.Name, _value)
+                            if _nameValue.id in constantStrings:
+                                moduleInfo[_key] = constantStrings[_nameValue.id]
+                            elif _nameValue.id in functionDefNames:
+                                classMethods.append(_key)
+                        elif _valueType == 'Attribute':
+                            _attributeValue = cast(ast.Attribute, _value)
+                            if _attributeValue.attr in methodDefNamesByClass[cast(ast.Name, _attributeValue.value).id]:
+                                classMethods.append(_key)
+                        elif _valueType in ("List", "Tuple"):
+                            _listValue = cast(ast.Tuple | ast.List, _value)
+                            values = [cast(ast.Constant, elt).value for elt in _listValue.elts]
+                            if _key == "imports":
+                                importURLs = values
+                            else:
+                                moduleInfo[_key] = values
+
+                    moduleInfo['classMethods'] = classMethods
+                    moduleInfo['importURLs'] = importURLs
+                    moduleInfo["moduleURL"] = moduleURL
+                    moduleInfo["path"] = moduleFilename
+                    moduleInfo["status"] = 'enabled'
+                    moduleInfo["fileDate"] = time.strftime('%Y-%m-%dT%H:%M:%S UTC', time.gmtime(os.path.getmtime(moduleFilename)))
+                    if entryPoint:
+                        distribution =  cast(Distribution, entryPoint.dist) if getattr(entryPoint, 'dist', None) else None
+                        version = distribution.version if distribution else None
+                        moduleInfo["moduleURL"] = moduleFilename  # pip-installed plugins need absolute filepath
+                        moduleInfo["entryPoint"] = {
+                            "module": entryPoint.module,
+                            "name": entryPoint.name,
+                            "version": version,
+                        }
+                        if not moduleInfo.get("version"):
+                            moduleInfo["version"] = version # If no explicit version, retrieve from entry point
+                elif isinstance(item.value, ast.Constant) and isinstance(item.value.value, str):  # possible constant used in plugininfo, such as VERSION
+                    for assignmentName in item.targets:
+                        constantStrings[cast(ast.Name, assignmentName).id] = item.value.value
+            elif isinstance(item, ast.ImportFrom):
+                if item.level == 1: # starts with .
+                    if item.module is None:  # from . import module1, module2, ...
+                        for importee in item.names:
+                            if importee.name == '*': #import all submodules
+                                for _file in os.listdir(moduleDir):
+                                    if _file != moduleName and os.path.isfile(_file) and _file.endswith(".py"):
+                                        moduleImports.append(_file)
+                            elif (os.path.isfile(os.path.join(moduleDir, importee.name + ".py"))
+                                  and importee.name not in moduleImports):
+                                moduleImports.append(importee.name)
+                    else:
+                        modulePkgs = item.module.split('.')
+                        modulePath = os.path.join(*modulePkgs)
+                        if (os.path.isfile(os.path.join(moduleDir, modulePath) + ".py")
+                                and modulePath not in moduleImports):
+                            moduleImports.append(modulePath)
+                        for importee in item.names:
+                            _importeePfxName = os.path.join(modulePath, importee.name)
+                            if (os.path.isfile(os.path.join(moduleDir, _importeePfxName) + ".py")
+                                    and _importeePfxName not in moduleImports):
+                                moduleImports.append(_importeePfxName)
+            elif isinstance(item, ast.FunctionDef): # possible functionDef used in plugininfo
+                functionDefNames.add(item.name)
+            elif isinstance(item, ast.ClassDef):  # possible ClassDef used in plugininfo
+                for classItem in item.body:
+                    if isinstance(classItem, ast.FunctionDef):
+                        methodDefNamesByClass[item.name].add(classItem.name)
+        moduleInfo["moduleImports"] = moduleImports
+        return moduleInfo if isPlugin else None
+
+
+    def moduleModuleInfo(
+            self,
+            moduleURL: str | None = None,
+            entryPoint: EntryPoint | None = None,
+            reload: bool = False,
+            parentImportsSubtree: bool = False) -> dict[TypeModuleInfoKey, Any] | None:
+        """
+        Generates a module info dict based on the provided `moduleURL` or `entryPoint`
+        Exactly one of "moduleURL" or "entryPoint" must be provided, otherwise a RuntimeError will be thrown.
+
+        When `moduleURL` is provided, it will be treated as a file path and will attempt to be normalized and
+        mapped to an existing plugin based on file location. If `moduleURL` fails to be mapped to an existing
+        plugin on its own, it will instead be used to search for an entry point. If found, this function will
+        proceed as if that entry point was provided for `entryPoint`.
+
+        When `entryPoint` is provided, it's location and other details will be used to generate the module info
+        dictionary.
+
+        :param moduleURL: A URL that loosely maps to the file location of a plugin (may be transformed)
+        :param entryPoint: An `EntryPoint` instance
+        :param reload:
+        :param parentImportsSubtree:
+        :return:s
+        """
+        if (moduleURL is None) == (entryPoint is None):
+            raise RuntimeError('Exactly one of "moduleURL" or "entryPoint" must be provided')
+        if entryPoint:
+            # If entry point is provided, use it to retrieve `moduleFilename`
+            moduleFilename = moduleURL = entryPoint.load()()
+        else:
+            assert moduleURL is not None
+            # Otherwise, we will verify the path before continuing
+            moduleFilename, entryPoint = self.getModuleFilename(moduleURL, reload=reload, normalize=True, base=_pluginBase)
+
+        if moduleFilename:
+            try:
+                self.logPluginTrace(f"Scanning module for plug-in info: {moduleFilename}", logging.INFO)
+                moduleInfo = self.parsePluginInfo(moduleURL, moduleFilename, entryPoint)
+                if moduleInfo is None:
+                    return None
+
+                moduleDir, moduleName = os.path.split(moduleFilename)
+                importURLs = moduleInfo["importURLs"]
+                del moduleInfo["importURLs"]
+                moduleImports = moduleInfo["moduleImports"]
+                del moduleInfo["moduleImports"]
+                moduleImportsSubtree = False
+                mergedImportURLs = []
+
+                for url in importURLs:
+                    if url.startswith("module_import"):
+                        for moduleImport in moduleImports:
+                            mergedImportURLs.append(moduleImport + ".py")
+                        if url == "module_import_subtree":
+                            moduleImportsSubtree = True
+                    elif url == "module_subtree":
+                        for _dir in os.listdir(moduleDir):
+                            subtreeModule = os.path.join(moduleDir,_dir)
+                            if os.path.isdir(subtreeModule) and _dir != "__pycache__":
+                                mergedImportURLs.append(subtreeModule)
+                    else:
+                        mergedImportURLs.append(url)
+                if parentImportsSubtree and not moduleImportsSubtree:
+                    moduleImportsSubtree = True
                     for moduleImport in moduleImports:
                         mergedImportURLs.append(moduleImport + ".py")
-                    if url == "module_import_subtree":
-                        moduleImportsSubtree = True
-                elif url == "module_subtree":
-                    for _dir in os.listdir(moduleDir):
-                        subtreeModule = os.path.join(moduleDir,_dir)
-                        if os.path.isdir(subtreeModule) and _dir != "__pycache__":
-                            mergedImportURLs.append(subtreeModule)
-                else:
-                    mergedImportURLs.append(url)
-            if parentImportsSubtree and not moduleImportsSubtree:
-                moduleImportsSubtree = True
-                for moduleImport in moduleImports:
-                    mergedImportURLs.append(moduleImport + ".py")
-            imports = []
-            for url in mergedImportURLs:
-                importURL = url
-                if not _isAbsoluteModuleURL(url):
-                    # Handle relative imports when plugin is loaded from external directory.
-                    # When EDGAR/render imports EDGAR/validate, this works if EDGAR is in the plugin directory
-                    # but fails if loaded externally (e.g., dev repo clone at /dev/path/to/EDGAR/).
-                    # Solution: Find common path segments to resolve /dev/path/to/EDGAR/validate
-                    # from the importing module at /dev/path/to/EDGAR/render.
-                    modulePath = Path(moduleFilename)
-                    importPath = Path(url)
-                    if importPath.parts:
-                        importFirstPart = importPath.parts[0]
-                        for i, modulePathPart in enumerate(reversed(modulePath.parts)):
-                            if modulePathPart != importFirstPart:
-                                continue
-                            # Found a potential branching point, construct and check a new path
-                            candidateImportURL = str(modulePath.parents[i] / importPath)
-                            if normalizeModuleFilename(candidateImportURL):
-                                importURL = candidateImportURL
-                importModuleInfo = moduleModuleInfo(moduleURL=importURL, reload=reload, parentImportsSubtree=moduleImportsSubtree)
-                if importModuleInfo:
-                    importModuleInfo["isImported"] = True
-                    imports.append(importModuleInfo)
-            moduleInfo["imports"] = imports
-            logPluginTrace(f"Successful module plug-in info: {moduleFilename}", logging.INFO)
-            return moduleInfo
-        except Exception as err:
-            _msg = _("Exception obtaining plug-in module info: {moduleFilename}\n{error}\n{traceback}").format(
-                    error=err, moduleFilename=moduleFilename, traceback=traceback.format_exc())
-            logPluginTrace(_msg, logging.ERROR)
-    return None
+                imports = []
+                for url in mergedImportURLs:
+                    importURL = url
+                    if not self._isAbsoluteModuleURL(url):
+                        # Handle relative imports when plugin is loaded from external directory.
+                        # When EDGAR/render imports EDGAR/validate, this works if EDGAR is in the plugin directory
+                        # but fails if loaded externally (e.g., dev repo clone at /dev/path/to/EDGAR/).
+                        # Solution: Find common path segments to resolve /dev/path/to/EDGAR/validate
+                        # from the importing module at /dev/path/to/EDGAR/render.
+                        modulePath = Path(moduleFilename)
+                        importPath = Path(url)
+                        if importPath.parts:
+                            importFirstPart = importPath.parts[0]
+                            for i, modulePathPart in enumerate(reversed(modulePath.parts)):
+                                if modulePathPart != importFirstPart:
+                                    continue
+                                # Found a potential branching point, construct and check a new path
+                                candidateImportURL = str(modulePath.parents[i] / importPath)
+                                if self.normalizeModuleFilename(candidateImportURL):
+                                    importURL = candidateImportURL
+                    importModuleInfo = self.moduleModuleInfo(moduleURL=importURL, reload=reload, parentImportsSubtree=moduleImportsSubtree)
+                    if importModuleInfo:
+                        importModuleInfo["isImported"] = True
+                        imports.append(importModuleInfo)
+                moduleInfo["imports"] = imports
+                self.logPluginTrace(f"Successful module plug-in info: {moduleFilename}", logging.INFO)
+                return moduleInfo
+            except Exception as err:
+                _msg = _("Exception obtaining plug-in module info: {moduleFilename}\n{error}\n{traceback}").format(
+                        error=err, moduleFilename=moduleFilename, traceback=traceback.format_exc())
+                self.logPluginTrace(_msg, logging.ERROR)
+        return None
 
 
-def moduleInfo(pluginInfo: Any) -> None:
-    """
-    This is an empty function in place for backwards compatability.
-    Will be removed in future release.
-    """
-    pass
+    @staticmethod
+    def moduleInfo(pluginInfo: Any) -> None:
+        """
+        This is an empty function in place for backwards compatability.
+        Will be removed in future release.
+        """
+        pass
 
 
-def _isAbsoluteModuleURL(moduleURL: str) -> bool:
-    return isAbsolute(moduleURL) or isLegacyAbs(moduleURL)
+    @staticmethod
+    def _isAbsoluteModuleURL(moduleURL: str) -> bool:
+        return isAbsolute(moduleURL) or isLegacyAbs(moduleURL)
 
 
-def _get_name_dir_prefix(modulePath: Path, packagePrefix: str = "") -> tuple[str | None, str | None, str | None]:
-    """Get the name, directory and prefix of a module."""
-    moduleName = None
-    moduleDir = None
-    packageImportPrefix = None
-    initFileName = "__init__.py"
+    @staticmethod
+    def _get_name_dir_prefix(modulePath: Path, packagePrefix: str = "") -> tuple[str | None, str | None, str | None]:
+        """Get the name, directory and prefix of a module."""
+        moduleName = None
+        moduleDir = None
+        packageImportPrefix = None
+        initFileName = "__init__.py"
 
-    if modulePath.is_file() and modulePath.name == initFileName:
-        modulePath = modulePath.parent
+        if modulePath.is_file() and modulePath.name == initFileName:
+            modulePath = modulePath.parent
 
-    if modulePath.is_dir() and (modulePath / initFileName).is_file():
-        moduleName = modulePath.name
-        moduleDir = str(modulePath.parent)
-        packageImportPrefix = moduleName + "."
-    elif modulePath.is_file() and modulePath.suffix == ".py":
-        moduleName = modulePath.stem
-        moduleDir = str(modulePath.parent)
-        packageImportPrefix = packagePrefix
+        if modulePath.is_dir() and (modulePath / initFileName).is_file():
+            moduleName = modulePath.name
+            moduleDir = str(modulePath.parent)
+            packageImportPrefix = moduleName + "."
+        elif modulePath.is_file() and modulePath.suffix == ".py":
+            moduleName = modulePath.stem
+            moduleDir = str(modulePath.parent)
+            packageImportPrefix = packagePrefix
 
-    return (moduleName, moduleDir, packageImportPrefix)
+        return (moduleName, moduleDir, packageImportPrefix)
 
-def _get_location(moduleDir: str, moduleName: str) -> Path:
-    """Get the file name of a plugin."""
-    module_name_path = Path(f"{moduleDir}/{moduleName}.py")
-    if os.path.isfile(module_name_path):
-        return module_name_path
+    @staticmethod
+    def _get_location(moduleDir: str, moduleName: str) -> Path:
+        """Get the file name of a plugin."""
+        module_name_path = Path(f"{moduleDir}/{moduleName}.py")
+        if os.path.isfile(module_name_path):
+            return module_name_path
 
-    return Path(f"{moduleDir}/{moduleName}/__init__.py")
+        return Path(f"{moduleDir}/{moduleName}/__init__.py")
 
-def _find_and_load_module(moduleDir: str, moduleName: str) -> ModuleType:
-    """Load a module based on name and directory."""
-    location = _get_location(moduleDir=moduleDir, moduleName=moduleName)
-    spec = importlib.util.spec_from_file_location(name=moduleName, location=location)
+    @staticmethod
+    def _find_and_load_module(moduleDir: str, moduleName: str) -> ModuleType:
+        """Load a module based on name and directory."""
+        location = PluginManager._get_location(moduleDir=moduleDir, moduleName=moduleName)
+        spec = importlib.util.spec_from_file_location(name=moduleName, location=location)
 
-    # spec_from_file_location returns ModuleSpec or None.
-    # spec.loader returns Loader or None.
-    # We want to make sure neither of them are None before proceeding
-    if spec is None or spec.loader is None:
-        raise ModuleNotFoundError("Unable to load module")
+        # spec_from_file_location returns ModuleSpec or None.
+        # spec.loader returns Loader or None.
+        # We want to make sure neither of them are None before proceeding
+        if spec is None or spec.loader is None:
+            raise ModuleNotFoundError("Unable to load module")
 
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[moduleName] = module # This line is required before exec_module
-    spec.loader.exec_module(sys.modules[moduleName])
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[moduleName] = module # This line is required before exec_module
+        spec.loader.exec_module(sys.modules[moduleName])
 
-    return sys.modules[moduleName]
+        return sys.modules[moduleName]
 
-def loadModule(moduleInfo: dict[TypeModuleInfoKey, Any], packagePrefix: str="") -> None:
-    name = moduleInfo['name']
-    moduleURL = moduleInfo['moduleURL']
-    modulePath = Path(moduleInfo['path'])
+    def loadModule(self, moduleInfo: dict[TypeModuleInfoKey, Any], packagePrefix: str="") -> None:
+        name = moduleInfo['name']
+        moduleURL = moduleInfo['moduleURL']
+        modulePath = Path(moduleInfo['path'])
 
-    moduleName, moduleDir, packageImportPrefix = _get_name_dir_prefix(modulePath, packagePrefix)
+        moduleName, moduleDir, packageImportPrefix = self._get_name_dir_prefix(modulePath, packagePrefix)
 
-    if all(p is None for p in [moduleName, moduleDir, packageImportPrefix]):
-        _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
-    else:
-        try:
-            if moduleDir is None or moduleName is None:
-                raise ModuleNotFoundError("Unable to load module")
-            module = _find_and_load_module(moduleDir=moduleDir, moduleName=moduleName)
-            pluginInfo = module.__pluginInfo__.copy()
-            elementSubstitutionClasses = None
-            if name == pluginInfo.get('name'):
-                pluginInfo["moduleURL"] = moduleURL
-                modulePluginInfos[name] = pluginInfo
-                if 'localeURL' in pluginInfo and module.__file__ is not None:
-                    # set L10N internationalization in loaded module
-                    localeDir = os.path.dirname(module.__file__) + os.sep + pluginInfo['localeURL']
-                    try:
-                        _gettext = gettext.translation(pluginInfo['localeDomain'], localeDir, getLanguageCodes())
-                    except OSError:
-                        def _gettext(x: Any) -> Any: # type: ignore[misc]
-                            return x # no translation
-                else:
-                    def _gettext(x: Any) -> Any: # type: ignore[misc]
-                        return x
-                for key, value in pluginInfo.items():
-                    if key == 'name':
-                        if name:
-                            pluginConfig['modules'][name] = moduleInfo
-                    elif isinstance(value, types.FunctionType):
-                        classModuleNames = pluginConfig['classes'].setdefault(key, [])
-                        if name and name not in classModuleNames:
-                            classModuleNames.append(name)
-                    if key == 'ModelObjectFactory.ElementSubstitutionClasses':
-                        elementSubstitutionClasses = value
-                module._ = _gettext # type: ignore[attr-defined]
-                global pluginConfigChanged
-                pluginConfigChanged = True
-            if elementSubstitutionClasses:
-                try:
-                    from arelle.ModelObjectFactory import elementSubstitutionModelClass
-                    elementSubstitutionModelClass.update(elementSubstitutionClasses)
-                except Exception as err:
-                    _msg = _("Exception loading plug-in {name}: processing ModelObjectFactory.ElementSubstitutionClasses").format(
-                            name=name, error=err)
-                    logPluginTrace(_msg, logging.ERROR)
-            if packageImportPrefix is not None:
-                for importModuleInfo in moduleInfo.get('imports', EMPTYLIST):
-                    loadModule(importModuleInfo, packageImportPrefix)
-        except (AttributeError, ImportError, FileNotFoundError, ModuleNotFoundError, TypeError, SystemError) as err:
-            # Send a summary of the error to the logger and retain the stacktrace for stderr
+        if all(p is None for p in [moduleName, moduleDir, packageImportPrefix]):
             _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
+        else:
+            try:
+                if moduleDir is None or moduleName is None:
+                    raise ModuleNotFoundError("Unable to load module")
+                module = self._find_and_load_module(moduleDir=moduleDir, moduleName=moduleName)
+                pluginInfo = module.__pluginInfo__.copy()
+                elementSubstitutionClasses = None
+                if name == pluginInfo.get('name'):
+                    pluginInfo["moduleURL"] = moduleURL
+                    modulePluginInfos[name] = pluginInfo
+                    if 'localeURL' in pluginInfo and module.__file__ is not None:
+                        # set L10N internationalization in loaded module
+                        localeDir = os.path.dirname(module.__file__) + os.sep + pluginInfo['localeURL']
+                        try:
+                            _gettext = gettext.translation(pluginInfo['localeDomain'], localeDir, getLanguageCodes())
+                        except OSError:
+                            def _gettext(x: Any) -> Any: # type: ignore[misc]
+                                return x # no translation
+                    else:
+                        def _gettext(x: Any) -> Any: # type: ignore[misc]
+                            return x
+                    for key, value in pluginInfo.items():
+                        if key == 'name':
+                            if name:
+                                pluginConfig['modules'][name] = moduleInfo
+                        elif isinstance(value, types.FunctionType):
+                            classModuleNames = pluginConfig['classes'].setdefault(key, [])
+                            if name and name not in classModuleNames:
+                                classModuleNames.append(name)
+                        if key == 'ModelObjectFactory.ElementSubstitutionClasses':
+                            elementSubstitutionClasses = value
+                    module._ = _gettext # type: ignore[attr-defined]
+                    global pluginConfigChanged
+                    pluginConfigChanged = True
+                if elementSubstitutionClasses:
+                    try:
+                        from arelle.ModelObjectFactory import elementSubstitutionModelClass
+                        elementSubstitutionModelClass.update(elementSubstitutionClasses)
+                    except Exception as err:
+                        _msg = _("Exception loading plug-in {name}: processing ModelObjectFactory.ElementSubstitutionClasses").format(
+                                name=name, error=err)
+                        self.logPluginTrace(_msg, logging.ERROR)
+                if packageImportPrefix is not None:
+                    for importModuleInfo in moduleInfo.get('imports', EMPTYLIST):
+                        self.loadModule(importModuleInfo, packageImportPrefix)
+            except (AttributeError, ImportError, FileNotFoundError, ModuleNotFoundError, TypeError, SystemError) as err:
+                # Send a summary of the error to the logger and retain the stacktrace for stderr
+                _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
 
-            _msg = _("Exception loading plug-in {name}: {error}\n{traceback}").format(
-                    name=name, error=err, traceback=traceback.format_exc())
-            logPluginTrace(_msg, logging.ERROR)
+                _msg = _("Exception loading plug-in {name}: {error}\n{traceback}").format(
+                        name=name, error=err, traceback=traceback.format_exc())
+                self.logPluginTrace(_msg, logging.ERROR)
 
 
-def hasPluginWithHook(name: str) -> bool:
-    return next(pluginClassMethods(name), None) is not None
+    def hasPluginWithHook(self, name: str) -> bool:
+        return next(self.pluginClassMethods(name), None) is not None
 
 
-def pluginClassMethods(className: str) -> Iterator[Callable[..., Any]]:
-    if pluginConfig:
-        try:
-            pluginMethodsForClass = pluginMethodsForClasses[className]
-        except KeyError:
-            # load all modules for class
-            pluginMethodsForClass = []
-            modulesNamesLoaded = set()
-            if className in pluginConfig["classes"]:
-                for moduleName in pluginConfig["classes"].get(className):
-                    if moduleName and moduleName in pluginConfig["modules"] and moduleName not in modulesNamesLoaded:
-                        modulesNamesLoaded.add(moduleName) # prevent multiply executing same class
-                        moduleInfo = pluginConfig["modules"][moduleName]
-                        if moduleInfo["status"] == "enabled":
-                            if moduleName not in modulePluginInfos:
-                                loadModule(moduleInfo)
-                            if moduleName in modulePluginInfos:
-                                pluginInfo = modulePluginInfos[moduleName]
-                                if className in pluginInfo:
-                                    pluginMethodsForClass.append(pluginInfo[className])
-            pluginMethodsForClasses[className] = pluginMethodsForClass
-        yield from pluginMethodsForClass
+    def pluginClassMethods(self, className: str) -> Iterator[Callable[..., Any]]:
+        if pluginConfig:
+            try:
+                pluginMethodsForClass = pluginMethodsForClasses[className]
+            except KeyError:
+                # load all modules for class
+                pluginMethodsForClass = []
+                modulesNamesLoaded = set()
+                if className in pluginConfig["classes"]:
+                    for moduleName in pluginConfig["classes"].get(className):
+                        if moduleName and moduleName in pluginConfig["modules"] and moduleName not in modulesNamesLoaded:
+                            modulesNamesLoaded.add(moduleName) # prevent multiply executing same class
+                            moduleInfo = pluginConfig["modules"][moduleName]
+                            if moduleInfo["status"] == "enabled":
+                                if moduleName not in modulePluginInfos:
+                                    self.loadModule(moduleInfo)
+                                if moduleName in modulePluginInfos:
+                                    pluginInfo = modulePluginInfos[moduleName]
+                                    if className in pluginInfo:
+                                        pluginMethodsForClass.append(pluginInfo[className])
+                pluginMethodsForClasses[className] = pluginMethodsForClass
+            yield from pluginMethodsForClass
 
 
-def addPluginModule(name: str) -> dict[TypeModuleInfoKey, Any] | None:
-    """
-    Discover plugin entry points with given name.
-    :param name: The name to search for
-    :return: The module information dictionary, if added. Otherwise, None.
-    """
-    entryPointRef = EntryPointRef.get(name)
-    pluginModuleInfo = None
-    if entryPointRef:
-        pluginModuleInfo = entryPointRef.createModuleInfo()
-    if not pluginModuleInfo or not pluginModuleInfo.get("name"):
-        pluginModuleInfo = moduleModuleInfo(moduleURL=name)
-    return addPluginModuleInfo(pluginModuleInfo)
+    def addPluginModule(self, name: str) -> dict[TypeModuleInfoKey, Any] | None:
+        """
+        Discover plugin entry points with given name.
+        :param name: The name to search for
+        :return: The module information dictionary, if added. Otherwise, None.
+        """
+        entryPointRef = EntryPointRef.get(name)
+        pluginModuleInfo = None
+        if entryPointRef:
+            pluginModuleInfo = entryPointRef.createModuleInfo()
+        if not pluginModuleInfo or not pluginModuleInfo.get("name"):
+            pluginModuleInfo = self.moduleModuleInfo(moduleURL=name)
+        return self.addPluginModuleInfo(pluginModuleInfo)
 
 
-def reloadPluginModule(name: str) -> bool:
-    if name in pluginConfig["modules"]:
-        url = pluginConfig["modules"][name].get("moduleURL")
-        if url:
-            moduleInfo = moduleModuleInfo(moduleURL=url, reload=True)
-            if moduleInfo:
-                addPluginModule(url)
-                return True
-    return False
+    def reloadPluginModule(self, name: str) -> bool:
+        if name in pluginConfig["modules"]:
+            url = pluginConfig["modules"][name].get("moduleURL")
+            if url:
+                moduleInfo = self.moduleModuleInfo(moduleURL=url, reload=True)
+                if moduleInfo:
+                    self.addPluginModule(url)
+                    return True
+        return False
 
-def removePluginModule(name: str) -> bool:
-    moduleInfo = pluginConfig["modules"].get(name)
-    if moduleInfo and name:
-        def _removePluginModule(moduleInfo: dict[TypeModuleInfoKey, Any]) -> None:
-            _name = moduleInfo.get("name")
-            if _name:
-                for classMethod in moduleInfo["classMethods"]:
-                    classMethods = pluginConfig["classes"].get(classMethod)
-                    if classMethods and _name and _name in classMethods:
-                        classMethods.remove(_name)
-                        if not classMethods: # list has become unused
-                            del pluginConfig["classes"][classMethod] # remove class
-                for importModuleInfo in moduleInfo.get('imports', EMPTYLIST):
-                    _removePluginModule(importModuleInfo)
-                pluginConfig["modules"].pop(_name, None)
-        _removePluginModule(moduleInfo)
+    def removePluginModule(self, name: str) -> bool:
+        moduleInfo = pluginConfig["modules"].get(name)
+        if moduleInfo and name:
+            def _removePluginModule(moduleInfo: dict[TypeModuleInfoKey, Any]) -> None:
+                _name = moduleInfo.get("name")
+                if _name:
+                    for classMethod in moduleInfo["classMethods"]:
+                        classMethods = pluginConfig["classes"].get(classMethod)
+                        if classMethods and _name and _name in classMethods:
+                            classMethods.remove(_name)
+                            if not classMethods: # list has become unused
+                                del pluginConfig["classes"][classMethod] # remove class
+                    for importModuleInfo in moduleInfo.get('imports', EMPTYLIST):
+                        _removePluginModule(importModuleInfo)
+                    pluginConfig["modules"].pop(_name, None)
+            _removePluginModule(moduleInfo)
+            global pluginConfigChanged
+            pluginConfigChanged = True
+            return True
+        return False # unable to remove
+
+
+    def addPluginModuleInfo(self, plugin_module_info: dict[TypeModuleInfoKey, Any] | None) -> dict[TypeModuleInfoKey, Any] | None:
+        """
+        Given a dictionary containing module information, loads plugin info into `pluginConfig`
+        :param plugin_module_info: Dictionary of module info fields. See comment block in PluginManager.py for structure.
+        :return: The module information dictionary, if added. Otherwise, None.
+        """
+        if not plugin_module_info or not plugin_module_info.get("name"):
+            return None
+        name = plugin_module_info["name"]
+        self.removePluginModule(name)  # remove any prior entry for this module
+
+        def _addPluginSubModule(subModuleInfo: dict[TypeModuleInfoKey, Any]) -> None:
+            """
+            Inline function for recursively exploring module imports
+            :param subModuleInfo: Module information to add.
+            :return:
+            """
+            _name = subModuleInfo.get("name")
+            if not _name:
+                return
+            # add classes
+            for classMethod in subModuleInfo["classMethods"]:
+                classMethods = pluginConfig["classes"].setdefault(classMethod, [])
+                _name = subModuleInfo["name"]
+                if _name and _name not in classMethods:
+                    classMethods.append(_name)
+            for importModuleInfo in subModuleInfo.get('imports', EMPTYLIST):
+                _addPluginSubModule(importModuleInfo)
+            pluginConfig["modules"][_name] = subModuleInfo
+
+        _addPluginSubModule(plugin_module_info)
         global pluginConfigChanged
         pluginConfigChanged = True
-        return True
-    return False # unable to remove
-
-
-def addPluginModuleInfo(plugin_module_info: dict[TypeModuleInfoKey, Any] | None) -> dict[TypeModuleInfoKey, Any] | None:
-    """
-    Given a dictionary containing module information, loads plugin info into `pluginConfig`
-    :param plugin_module_info: Dictionary of module info fields. See comment block in PluginManager.py for structure.
-    :return: The module information dictionary, if added. Otherwise, None.
-    """
-    if not plugin_module_info or not plugin_module_info.get("name"):
-        return None
-    name = plugin_module_info["name"]
-    removePluginModule(name)  # remove any prior entry for this module
-
-    def _addPluginSubModule(subModuleInfo: dict[TypeModuleInfoKey, Any]) -> None:
-        """
-        Inline function for recursively exploring module imports
-        :param subModuleInfo: Module information to add.
-        :return:
-        """
-        _name = subModuleInfo.get("name")
-        if not _name:
-            return
-        # add classes
-        for classMethod in subModuleInfo["classMethods"]:
-            classMethods = pluginConfig["classes"].setdefault(classMethod, [])
-            _name = subModuleInfo["name"]
-            if _name and _name not in classMethods:
-                classMethods.append(_name)
-        for importModuleInfo in subModuleInfo.get('imports', EMPTYLIST):
-            _addPluginSubModule(importModuleInfo)
-        pluginConfig["modules"][_name] = subModuleInfo
-
-    _addPluginSubModule(plugin_module_info)
-    global pluginConfigChanged
-    pluginConfigChanged = True
-    return plugin_module_info
+        return plugin_module_info
 
 
 _entryPointRefCache: list[EntryPointRef] | None = None
@@ -950,3 +960,121 @@ class EntryPointRef:
             _entryPointRefAliasCache = entryPointRefAliasCache
         search = EntryPointRef._normalizePluginSearchTerm(search)
         return _entryPointRefAliasCache.get(search, [])
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible module-level API
+#
+# These wrappers delegate to a module-level PluginManager singleton so that
+# existing callers (e.g. ``from arelle.PluginManager import pluginClassMethods``)
+# continue to work without modification.
+# ---------------------------------------------------------------------------
+
+_singleton: PluginManager | None = None
+
+
+def init(cntlr: Cntlr, loadPluginConfig: bool = True) -> None:
+    global _singleton
+    _singleton = PluginManager(cntlr, loadPluginConfig)
+
+
+def reset() -> None:
+    if _singleton is not None:
+        _singleton.reset()
+
+
+def orderedPluginConfig() -> dict[str, Any]:
+    assert _singleton is not None
+    return _singleton.orderedPluginConfig()
+
+
+def save(cntlr: Cntlr) -> None:
+    if _singleton is not None:
+        _singleton.save(cntlr)
+
+
+def close() -> None:
+    if _singleton is not None:
+        _singleton.close()
+
+
+def logPluginTrace(message: str, level: int) -> None:
+    if _singleton is not None:
+        _singleton.logPluginTrace(message, level)
+
+
+def modulesWithNewerFileDates() -> set[str]:
+    assert _singleton is not None
+    return _singleton.modulesWithNewerFileDates()
+
+
+def freshenModuleInfos() -> None:
+    if _singleton is not None:
+        _singleton.freshenModuleInfos()
+
+
+def normalizeModuleFilename(moduleFilename: str) -> str | None:
+    return PluginManager.normalizeModuleFilename(moduleFilename)
+
+
+def getModuleFilename(moduleURL: str, reload: bool, normalize: bool, base: str | None) -> tuple[str | None, EntryPoint | None]:
+    assert _singleton is not None
+    return _singleton.getModuleFilename(moduleURL, reload, normalize, base)
+
+
+def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint | None) -> dict[TypeModuleInfoKey, Any] | None:
+    assert _singleton is not None
+    return _singleton.parsePluginInfo(moduleURL, moduleFilename, entryPoint)
+
+
+def moduleModuleInfo(
+        moduleURL: str | None = None,
+        entryPoint: EntryPoint | None = None,
+        reload: bool = False,
+        parentImportsSubtree: bool = False) -> dict[TypeModuleInfoKey, Any] | None:
+    assert _singleton is not None
+    return _singleton.moduleModuleInfo(moduleURL=moduleURL, entryPoint=entryPoint, reload=reload, parentImportsSubtree=parentImportsSubtree)
+
+
+def moduleInfo(pluginInfo: Any) -> None:
+    PluginManager.moduleInfo(pluginInfo)
+
+
+def pluginClassMethods(className: str) -> Iterator[Callable[..., Any]]:
+    if _singleton is not None:
+        yield from _singleton.pluginClassMethods(className)
+
+
+def hasPluginWithHook(name: str) -> bool:
+    if _singleton is not None:
+        return _singleton.hasPluginWithHook(name)
+    return False
+
+
+def addPluginModule(name: str) -> dict[TypeModuleInfoKey, Any] | None:
+    assert _singleton is not None
+    return _singleton.addPluginModule(name)
+
+
+def reloadPluginModule(name: str) -> bool:
+    assert _singleton is not None
+    return _singleton.reloadPluginModule(name)
+
+
+def removePluginModule(name: str) -> bool:
+    assert _singleton is not None
+    return _singleton.removePluginModule(name)
+
+
+def addPluginModuleInfo(plugin_module_info: dict[TypeModuleInfoKey, Any] | None) -> dict[TypeModuleInfoKey, Any] | None:
+    assert _singleton is not None
+    return _singleton.addPluginModuleInfo(plugin_module_info)
+
+
+def loadModule(moduleInfo: dict[TypeModuleInfoKey, Any], packagePrefix: str = "") -> None:
+    assert _singleton is not None
+    _singleton.loadModule(moduleInfo, packagePrefix)
+
+
+def _get_name_dir_prefix(modulePath: Path, packagePrefix: str = "") -> tuple[str | None, str | None, str | None]:
+    return PluginManager._get_name_dir_prefix(modulePath, packagePrefix)

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import ast
 import gettext
-import warnings
 from glob import glob
 import importlib.util
 import json
@@ -789,10 +788,10 @@ class EntryPointRef:
     def createModuleInfo(self, plugin_manager: PluginManager | None = None) -> dict[TypeModuleInfoKey, Any] | None:
         """
         Creates a module information dictionary from the entry point ref.
-        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
+        :param plugin_manager: PluginManager instance for cache/state access.
         :return: A module information dictionary
         """
-        pm = plugin_manager or _singleton
+        pm = plugin_manager
         assert pm is not None
         if self.entryPoint is not None:
             return pm.moduleModuleInfo(entryPoint=self.entryPoint)
@@ -804,7 +803,7 @@ class EntryPointRef:
         Given an entry point, retrieves the subset of information from __pluginInfo__ necessary to
         determine if the entry point should be imported as a plugin.
         :param entryPoint:
-        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
+        :param plugin_manager: PluginManager instance for cache/state access.
         :return:
         """
         pluginUrlFunc = entryPoint.load()
@@ -818,10 +817,10 @@ class EntryPointRef:
         determine if the entry point should be imported as a plugin.
         :param filepath: Path to plugin, can be a directory or .py filepath
         :param entryPoint: Optional entry point information to include in aliases/moduleInfo
-        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
+        :param plugin_manager: PluginManager instance for cache/state access.
         :return:
         """
-        pm = plugin_manager or _singleton
+        pm = plugin_manager
         assert pm is not None
         moduleFilename = pm._cntlr.webCache.getfilename(filepath)
         if moduleFilename:
@@ -849,10 +848,10 @@ class EntryPointRef:
     def discoverAll(plugin_manager: PluginManager | None = None) -> list[EntryPointRef]:
         """
         Retrieve all plugin entry points, cached on first run.
-        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
+        :param plugin_manager: PluginManager instance for cache/state access.
         :return: List of all discovered entry points.
         """
-        pm = plugin_manager or _singleton
+        pm = plugin_manager
         assert pm is not None
         if pm._entryPointRefCache is None:
             pm._entryPointRefCache = EntryPointRef._discoverBuiltIn([], pm._pluginBase, plugin_manager=pm) + EntryPointRef._discoverInstalled(plugin_manager=pm)
@@ -864,7 +863,7 @@ class EntryPointRef:
         Recursively retrieve all plugin entry points in the given directory.
         :param entryPointRefs: Working list of entry point refs to append to.
         :param directory: Directory to search for entry points within.
-        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
+        :param plugin_manager: PluginManager instance for cache/state access.
         :return: List of discovered entry points.
         """
         for fileName in sorted(os.listdir(directory)):
@@ -890,7 +889,7 @@ class EntryPointRef:
     def _discoverInstalled(plugin_manager: PluginManager | None = None) -> list[EntryPointRef]:
         """
         Retrieve all installed plugin entry points.
-        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
+        :param plugin_manager: PluginManager instance for cache/state access.
         :return: List of all discovered entry points.
         """
         entryPoints = list(entry_points(group='arelle.plugin'))
@@ -908,7 +907,7 @@ class EntryPointRef:
         May return None of no matches are found.
         Throws an exception if multiple entry point refs match the search term.
         :param search: Only retrieve entry point matching the given search text.
-        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
+        :param plugin_manager: PluginManager instance for cache/state access.
         :return: Matching entry point ref, if found.
         """
         entryPointRefs = EntryPointRef.search(search, plugin_manager=plugin_manager)
@@ -944,10 +943,10 @@ class EntryPointRef:
         Retrieve entry point module information matching provided search text.
         A map of aliases to matching entry points is cached on the first run.
         :param search: Only retrieve entry points matching the given search text.
-        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
+        :param plugin_manager: PluginManager instance for cache/state access.
         :return: List of matching module infos.
         """
-        pm = plugin_manager or _singleton
+        pm = plugin_manager
         assert pm is not None
         if pm._entryPointRefAliasCache is None:
             entryPointRefAliasCache: dict[str, list[EntryPointRef]] = defaultdict(list)
@@ -958,165 +957,3 @@ class EntryPointRef:
             pm._entryPointRefAliasCache = entryPointRefAliasCache
         search = EntryPointRef._normalizePluginSearchTerm(search)
         return pm._entryPointRefAliasCache.get(search, [])
-
-
-# ---------------------------------------------------------------------------
-# Backward-compatible module-level API
-#
-# These wrappers delegate to a module-level PluginManager singleton so that
-# existing callers (e.g. ``from arelle.PluginManager import pluginClassMethods``)
-# continue to work without modification.
-# ---------------------------------------------------------------------------
-
-_singleton: PluginManager | None = None
-
-_SINGLETON_ATTRS = frozenset({
-    "pluginJsonFile", "pluginConfig", "pluginConfigChanged",
-    "pluginTraceFileLogger", "modulePluginInfos", "pluginMethodsForClasses",
-    "_cntlr", "_pluginBase",
-    "_entryPointRefCache", "_entryPointRefAliasCache",
-})
-
-
-def _deprecated(name: str) -> None:
-    warnings.warn(
-        f"arelle.PluginManager.{name} is deprecated. "
-        "Use cntlr.pluginManager instead.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
-
-
-def __getattr__(name: str) -> Any:
-    if name in _SINGLETON_ATTRS and _singleton is not None:
-        _deprecated(name)
-        return getattr(_singleton, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def init(cntlr: Cntlr, loadPluginConfig: bool = True) -> None:
-    _deprecated("init")
-    global _singleton
-    _singleton = PluginManager(cntlr, loadPluginConfig)
-
-
-def reset() -> None:
-    _deprecated("reset")
-    if _singleton is not None:
-        _singleton.reset()
-
-
-def orderedPluginConfig() -> dict[str, Any]:
-    _deprecated("orderedPluginConfig")
-    assert _singleton is not None
-    return _singleton.orderedPluginConfig()
-
-
-def save(cntlr: Cntlr) -> None:
-    _deprecated("save")
-    if _singleton is not None:
-        _singleton.save(cntlr)
-
-
-def close() -> None:
-    _deprecated("close")
-    if _singleton is not None:
-        _singleton.close()
-
-
-def logPluginTrace(message: str, level: int) -> None:
-    _deprecated("logPluginTrace")
-    if _singleton is not None:
-        _singleton.logPluginTrace(message, level)
-
-
-def modulesWithNewerFileDates() -> set[str]:
-    _deprecated("modulesWithNewerFileDates")
-    assert _singleton is not None
-    return _singleton.modulesWithNewerFileDates()
-
-
-def freshenModuleInfos() -> None:
-    _deprecated("freshenModuleInfos")
-    if _singleton is not None:
-        _singleton.freshenModuleInfos()
-
-
-def normalizeModuleFilename(moduleFilename: str) -> str | None:
-    _deprecated("normalizeModuleFilename")
-    return PluginManager.normalizeModuleFilename(moduleFilename)
-
-
-def getModuleFilename(moduleURL: str, reload: bool, normalize: bool, base: str | None) -> tuple[str | None, EntryPoint | None]:
-    _deprecated("getModuleFilename")
-    assert _singleton is not None
-    return _singleton.getModuleFilename(moduleURL, reload, normalize, base)
-
-
-def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint | None) -> dict[TypeModuleInfoKey, Any] | None:
-    _deprecated("parsePluginInfo")
-    assert _singleton is not None
-    return _singleton.parsePluginInfo(moduleURL, moduleFilename, entryPoint)
-
-
-def moduleModuleInfo(
-        moduleURL: str | None = None,
-        entryPoint: EntryPoint | None = None,
-        reload: bool = False,
-        parentImportsSubtree: bool = False) -> dict[TypeModuleInfoKey, Any] | None:
-    _deprecated("moduleModuleInfo")
-    assert _singleton is not None
-    return _singleton.moduleModuleInfo(moduleURL=moduleURL, entryPoint=entryPoint, reload=reload, parentImportsSubtree=parentImportsSubtree)
-
-
-def moduleInfo(pluginInfo: Any) -> None:
-    _deprecated("moduleInfo")
-    PluginManager.moduleInfo(pluginInfo)
-
-
-def pluginClassMethods(className: str) -> Iterator[Callable[..., Any]]:
-    _deprecated("pluginClassMethods")
-    if _singleton is not None:
-        yield from _singleton.pluginClassMethods(className)
-
-
-def hasPluginWithHook(name: str) -> bool:
-    _deprecated("hasPluginWithHook")
-    if _singleton is not None:
-        return _singleton.hasPluginWithHook(name)
-    return False
-
-
-def addPluginModule(name: str) -> dict[TypeModuleInfoKey, Any] | None:
-    _deprecated("addPluginModule")
-    assert _singleton is not None
-    return _singleton.addPluginModule(name)
-
-
-def reloadPluginModule(name: str) -> bool:
-    _deprecated("reloadPluginModule")
-    assert _singleton is not None
-    return _singleton.reloadPluginModule(name)
-
-
-def removePluginModule(name: str) -> bool:
-    _deprecated("removePluginModule")
-    assert _singleton is not None
-    return _singleton.removePluginModule(name)
-
-
-def addPluginModuleInfo(plugin_module_info: dict[TypeModuleInfoKey, Any] | None) -> dict[TypeModuleInfoKey, Any] | None:
-    _deprecated("addPluginModuleInfo")
-    assert _singleton is not None
-    return _singleton.addPluginModuleInfo(plugin_module_info)
-
-
-def loadModule(moduleInfo: dict[TypeModuleInfoKey, Any], packagePrefix: str = "") -> None:
-    _deprecated("loadModule")
-    assert _singleton is not None
-    _singleton.loadModule(moduleInfo, packagePrefix)
-
-
-def _get_name_dir_prefix(modulePath: Path, packagePrefix: str = "") -> tuple[str | None, str | None, str | None]:
-    _deprecated("_get_name_dir_prefix")
-    return PluginManager._get_name_dir_prefix(modulePath, packagePrefix)

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import ast
 import gettext
+import warnings
 from glob import glob
 import importlib.util
 import json
@@ -977,62 +978,83 @@ _SINGLETON_ATTRS = frozenset({
 })
 
 
+def _deprecated(name: str) -> None:
+    warnings.warn(
+        f"arelle.PluginManager.{name} is deprecated. "
+        "Use cntlr.pluginManager instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
 def __getattr__(name: str) -> Any:
     if name in _SINGLETON_ATTRS and _singleton is not None:
+        _deprecated(name)
         return getattr(_singleton, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def init(cntlr: Cntlr, loadPluginConfig: bool = True) -> None:
+    _deprecated("init")
     global _singleton
     _singleton = PluginManager(cntlr, loadPluginConfig)
 
 
 def reset() -> None:
+    _deprecated("reset")
     if _singleton is not None:
         _singleton.reset()
 
 
 def orderedPluginConfig() -> dict[str, Any]:
+    _deprecated("orderedPluginConfig")
     assert _singleton is not None
     return _singleton.orderedPluginConfig()
 
 
 def save(cntlr: Cntlr) -> None:
+    _deprecated("save")
     if _singleton is not None:
         _singleton.save(cntlr)
 
 
 def close() -> None:
+    _deprecated("close")
     if _singleton is not None:
         _singleton.close()
 
 
 def logPluginTrace(message: str, level: int) -> None:
+    _deprecated("logPluginTrace")
     if _singleton is not None:
         _singleton.logPluginTrace(message, level)
 
 
 def modulesWithNewerFileDates() -> set[str]:
+    _deprecated("modulesWithNewerFileDates")
     assert _singleton is not None
     return _singleton.modulesWithNewerFileDates()
 
 
 def freshenModuleInfos() -> None:
+    _deprecated("freshenModuleInfos")
     if _singleton is not None:
         _singleton.freshenModuleInfos()
 
 
 def normalizeModuleFilename(moduleFilename: str) -> str | None:
+    _deprecated("normalizeModuleFilename")
     return PluginManager.normalizeModuleFilename(moduleFilename)
 
 
 def getModuleFilename(moduleURL: str, reload: bool, normalize: bool, base: str | None) -> tuple[str | None, EntryPoint | None]:
+    _deprecated("getModuleFilename")
     assert _singleton is not None
     return _singleton.getModuleFilename(moduleURL, reload, normalize, base)
 
 
 def parsePluginInfo(moduleURL: str, moduleFilename: str, entryPoint: EntryPoint | None) -> dict[TypeModuleInfoKey, Any] | None:
+    _deprecated("parsePluginInfo")
     assert _singleton is not None
     return _singleton.parsePluginInfo(moduleURL, moduleFilename, entryPoint)
 
@@ -1042,49 +1064,59 @@ def moduleModuleInfo(
         entryPoint: EntryPoint | None = None,
         reload: bool = False,
         parentImportsSubtree: bool = False) -> dict[TypeModuleInfoKey, Any] | None:
+    _deprecated("moduleModuleInfo")
     assert _singleton is not None
     return _singleton.moduleModuleInfo(moduleURL=moduleURL, entryPoint=entryPoint, reload=reload, parentImportsSubtree=parentImportsSubtree)
 
 
 def moduleInfo(pluginInfo: Any) -> None:
+    _deprecated("moduleInfo")
     PluginManager.moduleInfo(pluginInfo)
 
 
 def pluginClassMethods(className: str) -> Iterator[Callable[..., Any]]:
+    _deprecated("pluginClassMethods")
     if _singleton is not None:
         yield from _singleton.pluginClassMethods(className)
 
 
 def hasPluginWithHook(name: str) -> bool:
+    _deprecated("hasPluginWithHook")
     if _singleton is not None:
         return _singleton.hasPluginWithHook(name)
     return False
 
 
 def addPluginModule(name: str) -> dict[TypeModuleInfoKey, Any] | None:
+    _deprecated("addPluginModule")
     assert _singleton is not None
     return _singleton.addPluginModule(name)
 
 
 def reloadPluginModule(name: str) -> bool:
+    _deprecated("reloadPluginModule")
     assert _singleton is not None
     return _singleton.reloadPluginModule(name)
 
 
 def removePluginModule(name: str) -> bool:
+    _deprecated("removePluginModule")
     assert _singleton is not None
     return _singleton.removePluginModule(name)
 
 
 def addPluginModuleInfo(plugin_module_info: dict[TypeModuleInfoKey, Any] | None) -> dict[TypeModuleInfoKey, Any] | None:
+    _deprecated("addPluginModuleInfo")
     assert _singleton is not None
     return _singleton.addPluginModuleInfo(plugin_module_info)
 
 
 def loadModule(moduleInfo: dict[TypeModuleInfoKey, Any], packagePrefix: str = "") -> None:
+    _deprecated("loadModule")
     assert _singleton is not None
     _singleton.loadModule(moduleInfo, packagePrefix)
 
 
 def _get_name_dir_prefix(modulePath: Path, packagePrefix: str = "") -> tuple[str | None, str | None, str | None]:
+    _deprecated("_get_name_dir_prefix")
     return PluginManager._get_name_dir_prefix(modulePath, packagePrefix)

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -40,21 +40,6 @@ PLUGIN_TRACE_FILE: str | None = None
 # PLUGIN_TRACE_FILE = "c:/temp/pluginerr.txt"
 PLUGIN_TRACE_LEVEL = logging.WARNING
 
-# plugin control is static to correspond to statically loaded modules
-pluginJsonFile = None
-# The code in this module mostly assumes these values are not `NoneType` and
-# relies on try/except catching AttributeError, TypeError, etc. if they ever are.
-# Rather than add type casting or assertions throughout the code, we will ignore
-# the assignment type hint error here and rely on the initialization process to set
-# these values before use.
-pluginConfig: dict[str, Any] = None # type: ignore[assignment]
-_cntlr: Cntlr = None # type: ignore[assignment]
-
-pluginConfigChanged = False
-pluginTraceFileLogger = None
-modulePluginInfos: dict[str, Any] = {}
-pluginMethodsForClasses: dict[str, Any] = {}
-_pluginBase = None
 EMPTYLIST: list[Any] = []
 _ERROR_MESSAGE_IMPORT_TEMPLATE = "Unable to load module {}"
 
@@ -66,40 +51,43 @@ TypeModuleInfoKey = Union[
 class PluginManager:
 
     def __init__(self, cntlr: Cntlr, loadPluginConfig: bool = True) -> None:
-        global pluginJsonFile, pluginConfig, pluginTraceFileLogger, modulePluginInfos, pluginMethodsForClasses, pluginConfigChanged, _cntlr, _pluginBase
+        self.pluginJsonFile: str | None = None
+        self.pluginConfig: dict[str, Any] = None  # type: ignore[assignment]
+        self._cntlr: Cntlr = cntlr
+        self.pluginConfigChanged = False
+        self.pluginTraceFileLogger: logging.Logger | None = None
+        self.modulePluginInfos: dict[str, Any] = {}
+        self.pluginMethodsForClasses: dict[str, Any] = {}
+        self._pluginBase: str = cntlr.pluginDir + os.sep
+
         if PLUGIN_TRACE_FILE:
-            pluginTraceFileLogger = logging.getLogger(__name__)
-            pluginTraceFileLogger.propagate = False
+            self.pluginTraceFileLogger = logging.getLogger(__name__)
+            self.pluginTraceFileLogger.propagate = False
             handler = logging.FileHandler(PLUGIN_TRACE_FILE)
             formatter = logging.Formatter('%(asctime)s.%(msecs)03dz [%(levelname)s] %(message)s', datefmt='%Y-%m-%dT%H:%M:%S')
             handler.setFormatter(formatter)
             handler.setLevel(PLUGIN_TRACE_LEVEL)
-            pluginTraceFileLogger.addHandler(handler)
-        pluginConfigChanged = False
-        _cntlr = cntlr
-        _pluginBase = cntlr.pluginDir + os.sep
+            self.pluginTraceFileLogger.addHandler(handler)
         if loadPluginConfig:
             try:
-                pluginJsonFile = cntlr.userAppDir + os.sep + "plugins.json"
-                with open(pluginJsonFile, encoding='utf-8') as f:
-                    pluginConfig = json.load(f)
+                self.pluginJsonFile = cntlr.userAppDir + os.sep + "plugins.json"
+                with open(self.pluginJsonFile, encoding='utf-8') as f:
+                    self.pluginConfig = json.load(f)
                 self.freshenModuleInfos()
             except Exception:
                 pass # on GAE no userAppDir, will always come here
-        if not pluginConfig:
-            pluginConfig = {  # savable/reloadable plug in configuration
+        if not self.pluginConfig:
+            self.pluginConfig = {  # savable/reloadable plug in configuration
                 "modules": {}, # dict of moduleInfos by module name
                 "classes": {}  # dict by class name of list of class modules in execution order
             }
-            pluginConfigChanged = False # don't save until something is added to pluginConfig
-        modulePluginInfos = {}  # dict of loaded module pluginInfo objects by module names
-        pluginMethodsForClasses = {} # dict by class of list of ordered callable function objects
+            self.pluginConfigChanged = False # don't save until something is added to pluginConfig
 
     def reset(self) -> None:  # force reloading modules and plugin infos
-        if modulePluginInfos:
-            modulePluginInfos.clear()  # dict of loaded module pluginInfo objects by module names
-        if pluginMethodsForClasses:
-            pluginMethodsForClasses.clear() # dict by class of list of ordered callable function objects
+        if self.modulePluginInfos:
+            self.modulePluginInfos.clear()  # dict of loaded module pluginInfo objects by module names
+        if self.pluginMethodsForClasses:
+            self.pluginMethodsForClasses.clear() # dict by class of list of ordered callable function objects
 
     def orderedPluginConfig(self) -> dict[str, Any]:
         fieldOrder: list[TypeModuleInfoKey] = [
@@ -127,31 +115,30 @@ class PluginManager:
             return {k: moduleInfo[k] for k in orderedKeys}
 
         orderedModules = {
-            moduleName: sortModuleInfo(pluginConfig['modules'][moduleName])
-            for moduleName in sorted(pluginConfig['modules'].keys())
+            moduleName: sortModuleInfo(self.pluginConfig['modules'][moduleName])
+            for moduleName in sorted(self.pluginConfig['modules'].keys())
         }
 
         return {
             'modules': orderedModules,
-            'classes': dict(sorted(pluginConfig['classes'].items()))
+            'classes': dict(sorted(self.pluginConfig['classes'].items()))
         }
 
     def save(self, cntlr: Cntlr) -> None:
-        global pluginConfigChanged
-        if pluginConfigChanged and cntlr.hasFileSystem and not cntlr.disablePersistentConfig:
+        if self.pluginConfigChanged and cntlr.hasFileSystem and not cntlr.disablePersistentConfig:
             pluginJsonFile = cntlr.userAppDir + os.sep + "plugins.json"
             with open(pluginJsonFile, 'w', encoding='utf-8') as f:
                 jsonStr = str(json.dumps(self.orderedPluginConfig(), ensure_ascii=False, indent=2)) # might not be unicode in 2.7
                 f.write(jsonStr)
-            pluginConfigChanged = False
+            self.pluginConfigChanged = False
 
     def close(self) -> None:  # close all loaded methods
-        if pluginConfig is not None:
-            pluginConfig.clear()
-        if modulePluginInfos is not None:
-            modulePluginInfos.clear()
-        if pluginMethodsForClasses is not None:
-            pluginMethodsForClasses.clear()
+        if self.pluginConfig is not None:
+            self.pluginConfig.clear()
+        if self.modulePluginInfos is not None:
+            self.modulePluginInfos.clear()
+        if self.pluginMethodsForClasses is not None:
+            self.pluginMethodsForClasses.clear()
 
     ''' pluginInfo structure:
 
@@ -199,16 +186,16 @@ class PluginManager:
         :param message: Message to be logged
         :param level: Log level of message (e.g. logging.INFO)
         """
-        if pluginTraceFileLogger:
-            pluginTraceFileLogger.log(level, message)
+        if self.pluginTraceFileLogger:
+            self.pluginTraceFileLogger.log(level, message)
         if level >= logging.ERROR:
-            _cntlr.addToLog(message=message, level=level, messageCode='arelle:pluginLoadingError')
+            self._cntlr.addToLog(message=message, level=level, messageCode='arelle:pluginLoadingError')
 
 
     def modulesWithNewerFileDates(self) -> set[str]:
         names = set()
-        for moduleName, moduleInfo in pluginConfig["modules"].items():
-            freshenedFilename = _cntlr.webCache.getfilename(moduleInfo["moduleURL"], checkModifiedTime=True, normalize=True, base=_pluginBase)
+        for moduleName, moduleInfo in self.pluginConfig["modules"].items():
+            freshenedFilename = self._cntlr.webCache.getfilename(moduleInfo["moduleURL"], checkModifiedTime=True, normalize=True, base=self._pluginBase)
             if freshenedFilename is None:
                 _msg = _("Module URL could not be mapped to a filepath: {moduleURL}").format(moduleURL=moduleInfo["moduleURL"])
                 self.logPluginTrace(_msg, logging.ERROR)
@@ -235,9 +222,9 @@ class PluginManager:
     def freshenModuleInfos(self) -> None:
         # for modules with different date-times, re-load module info
         missingEnabledModules = []
-        for moduleName, moduleInfo in pluginConfig["modules"].items():
+        for moduleName, moduleInfo in self.pluginConfig["modules"].items():
             moduleEnabled = moduleInfo["status"] == "enabled"
-            freshenedFilename = _cntlr.webCache.getfilename(moduleInfo["moduleURL"], checkModifiedTime=True, normalize=True, base=_pluginBase)
+            freshenedFilename = self._cntlr.webCache.getfilename(moduleInfo["moduleURL"], checkModifiedTime=True, normalize=True, base=self._pluginBase)
             if freshenedFilename is None:
                 _msg = _("Module URL could not be mapped to a filepath: {moduleURL}").format(moduleURL=moduleInfo["moduleURL"])
                 self.logPluginTrace(_msg, logging.ERROR)
@@ -253,7 +240,7 @@ class PluginManager:
                         freshenedModuleInfo = self.moduleModuleInfo(moduleURL=moduleInfo["moduleURL"], reload=True)
                         if freshenedModuleInfo is not None:
                             if freshenedModuleInfo["name"] == moduleName:
-                                pluginConfig["modules"][moduleName] = freshenedModuleInfo
+                                self.pluginConfig["modules"][moduleName] = freshenedModuleInfo
                             else:
                                 # Module has been re-named
                                 if moduleEnabled:
@@ -273,12 +260,12 @@ class PluginManager:
             # Try re-adding plugin modules by name (for plugins that moved from built-in to pip installed)
             moduleInfo = self.addPluginModule(moduleName)
             if moduleInfo:
-                pluginConfig["modules"][moduleInfo["name"]] = moduleInfo
+                self.pluginConfig["modules"][moduleInfo["name"]] = moduleInfo
                 self.loadModule(moduleInfo)
                 self.logPluginTrace(_("Reloaded plugin that failed loading: {} {}").format(moduleName, moduleInfo), logging.INFO)
             else:
                 self.logPluginTrace(_("Removed plugin that failed loading (plugin may have been archived): {}").format(moduleName), logging.ERROR)
-        self.save(_cntlr)
+        self.save(self._cntlr)
 
 
     @staticmethod
@@ -312,7 +299,7 @@ class PluginManager:
 
     def getModuleFilename(self, moduleURL: str, reload: bool, normalize: bool, base: str | None) -> tuple[str | None, EntryPoint | None]:
         #TODO several directories, eg User Application Data
-        moduleFilename = _cntlr.webCache.getfilename(moduleURL, reload=reload, normalize=normalize, base=base)
+        moduleFilename = self._cntlr.webCache.getfilename(moduleURL, reload=reload, normalize=normalize, base=base)
         if moduleFilename:
             # `moduleURL` was mapped to a local filepath
             moduleFilename = self.normalizeModuleFilename(moduleFilename)
@@ -337,7 +324,7 @@ class PluginManager:
 
     def parsePluginInfo(self, moduleURL: str, moduleFilename: str, entryPoint: EntryPoint | None) -> dict[TypeModuleInfoKey, Any] | None:
         moduleDir, moduleName = os.path.split(moduleFilename)
-        with arelle.FileSource.openFileStream(_cntlr, moduleFilename) as f:
+        with arelle.FileSource.openFileStream(self._cntlr, moduleFilename) as f:
             contents = f.read()
             if '__pluginInfo__' not in contents:
                 return None
@@ -480,7 +467,7 @@ class PluginManager:
         else:
             assert moduleURL is not None
             # Otherwise, we will verify the path before continuing
-            moduleFilename, entryPoint = self.getModuleFilename(moduleURL, reload=reload, normalize=True, base=_pluginBase)
+            moduleFilename, entryPoint = self.getModuleFilename(moduleURL, reload=reload, normalize=True, base=self._pluginBase)
 
         if moduleFilename:
             try:
@@ -619,7 +606,7 @@ class PluginManager:
         moduleName, moduleDir, packageImportPrefix = self._get_name_dir_prefix(modulePath, packagePrefix)
 
         if all(p is None for p in [moduleName, moduleDir, packageImportPrefix]):
-            _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
+            self._cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
         else:
             try:
                 if moduleDir is None or moduleName is None:
@@ -629,7 +616,7 @@ class PluginManager:
                 elementSubstitutionClasses = None
                 if name == pluginInfo.get('name'):
                     pluginInfo["moduleURL"] = moduleURL
-                    modulePluginInfos[name] = pluginInfo
+                    self.modulePluginInfos[name] = pluginInfo
                     if 'localeURL' in pluginInfo and module.__file__ is not None:
                         # set L10N internationalization in loaded module
                         localeDir = os.path.dirname(module.__file__) + os.sep + pluginInfo['localeURL']
@@ -644,16 +631,15 @@ class PluginManager:
                     for key, value in pluginInfo.items():
                         if key == 'name':
                             if name:
-                                pluginConfig['modules'][name] = moduleInfo
+                                self.pluginConfig['modules'][name] = moduleInfo
                         elif isinstance(value, types.FunctionType):
-                            classModuleNames = pluginConfig['classes'].setdefault(key, [])
+                            classModuleNames = self.pluginConfig['classes'].setdefault(key, [])
                             if name and name not in classModuleNames:
                                 classModuleNames.append(name)
                         if key == 'ModelObjectFactory.ElementSubstitutionClasses':
                             elementSubstitutionClasses = value
                     module._ = _gettext # type: ignore[attr-defined]
-                    global pluginConfigChanged
-                    pluginConfigChanged = True
+                    self.pluginConfigChanged = True
                 if elementSubstitutionClasses:
                     try:
                         from arelle.ModelObjectFactory import elementSubstitutionModelClass
@@ -667,7 +653,7 @@ class PluginManager:
                         self.loadModule(importModuleInfo, packageImportPrefix)
             except (AttributeError, ImportError, FileNotFoundError, ModuleNotFoundError, TypeError, SystemError) as err:
                 # Send a summary of the error to the logger and retain the stacktrace for stderr
-                _cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
+                self._cntlr.addToLog(message=_ERROR_MESSAGE_IMPORT_TEMPLATE.format(name), level=logging.ERROR)
 
                 _msg = _("Exception loading plug-in {name}: {error}\n{traceback}").format(
                         name=name, error=err, traceback=traceback.format_exc())
@@ -679,26 +665,26 @@ class PluginManager:
 
 
     def pluginClassMethods(self, className: str) -> Iterator[Callable[..., Any]]:
-        if pluginConfig:
+        if self.pluginConfig:
             try:
-                pluginMethodsForClass = pluginMethodsForClasses[className]
+                pluginMethodsForClass = self.pluginMethodsForClasses[className]
             except KeyError:
                 # load all modules for class
                 pluginMethodsForClass = []
                 modulesNamesLoaded = set()
-                if className in pluginConfig["classes"]:
-                    for moduleName in pluginConfig["classes"].get(className):
-                        if moduleName and moduleName in pluginConfig["modules"] and moduleName not in modulesNamesLoaded:
+                if className in self.pluginConfig["classes"]:
+                    for moduleName in self.pluginConfig["classes"].get(className):
+                        if moduleName and moduleName in self.pluginConfig["modules"] and moduleName not in modulesNamesLoaded:
                             modulesNamesLoaded.add(moduleName) # prevent multiply executing same class
-                            moduleInfo = pluginConfig["modules"][moduleName]
+                            moduleInfo = self.pluginConfig["modules"][moduleName]
                             if moduleInfo["status"] == "enabled":
-                                if moduleName not in modulePluginInfos:
+                                if moduleName not in self.modulePluginInfos:
                                     self.loadModule(moduleInfo)
-                                if moduleName in modulePluginInfos:
-                                    pluginInfo = modulePluginInfos[moduleName]
+                                if moduleName in self.modulePluginInfos:
+                                    pluginInfo = self.modulePluginInfos[moduleName]
                                     if className in pluginInfo:
                                         pluginMethodsForClass.append(pluginInfo[className])
-                pluginMethodsForClasses[className] = pluginMethodsForClass
+                self.pluginMethodsForClasses[className] = pluginMethodsForClass
             yield from pluginMethodsForClass
 
 
@@ -718,8 +704,8 @@ class PluginManager:
 
 
     def reloadPluginModule(self, name: str) -> bool:
-        if name in pluginConfig["modules"]:
-            url = pluginConfig["modules"][name].get("moduleURL")
+        if name in self.pluginConfig["modules"]:
+            url = self.pluginConfig["modules"][name].get("moduleURL")
             if url:
                 moduleInfo = self.moduleModuleInfo(moduleURL=url, reload=True)
                 if moduleInfo:
@@ -728,23 +714,22 @@ class PluginManager:
         return False
 
     def removePluginModule(self, name: str) -> bool:
-        moduleInfo = pluginConfig["modules"].get(name)
+        moduleInfo = self.pluginConfig["modules"].get(name)
         if moduleInfo and name:
             def _removePluginModule(moduleInfo: dict[TypeModuleInfoKey, Any]) -> None:
                 _name = moduleInfo.get("name")
                 if _name:
                     for classMethod in moduleInfo["classMethods"]:
-                        classMethods = pluginConfig["classes"].get(classMethod)
+                        classMethods = self.pluginConfig["classes"].get(classMethod)
                         if classMethods and _name and _name in classMethods:
                             classMethods.remove(_name)
                             if not classMethods: # list has become unused
-                                del pluginConfig["classes"][classMethod] # remove class
+                                del self.pluginConfig["classes"][classMethod] # remove class
                     for importModuleInfo in moduleInfo.get('imports', EMPTYLIST):
                         _removePluginModule(importModuleInfo)
-                    pluginConfig["modules"].pop(_name, None)
+                    self.pluginConfig["modules"].pop(_name, None)
             _removePluginModule(moduleInfo)
-            global pluginConfigChanged
-            pluginConfigChanged = True
+            self.pluginConfigChanged = True
             return True
         return False # unable to remove
 
@@ -771,17 +756,16 @@ class PluginManager:
                 return
             # add classes
             for classMethod in subModuleInfo["classMethods"]:
-                classMethods = pluginConfig["classes"].setdefault(classMethod, [])
+                classMethods = self.pluginConfig["classes"].setdefault(classMethod, [])
                 _name = subModuleInfo["name"]
                 if _name and _name not in classMethods:
                     classMethods.append(_name)
             for importModuleInfo in subModuleInfo.get('imports', EMPTYLIST):
                 _addPluginSubModule(importModuleInfo)
-            pluginConfig["modules"][_name] = subModuleInfo
+            self.pluginConfig["modules"][_name] = subModuleInfo
 
         _addPluginSubModule(plugin_module_info)
-        global pluginConfigChanged
-        pluginConfigChanged = True
+        self.pluginConfigChanged = True
         return plugin_module_info
 
 
@@ -971,6 +955,18 @@ class EntryPointRef:
 # ---------------------------------------------------------------------------
 
 _singleton: PluginManager | None = None
+
+_SINGLETON_ATTRS = frozenset({
+    "pluginJsonFile", "pluginConfig", "pluginConfigChanged",
+    "pluginTraceFileLogger", "modulePluginInfos", "pluginMethodsForClasses",
+    "_cntlr", "_pluginBase",
+})
+
+
+def __getattr__(name: str) -> Any:
+    if name in _SINGLETON_ATTRS and _singleton is not None:
+        return getattr(_singleton, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def init(cntlr: Cntlr, loadPluginConfig: bool = True) -> None:

--- a/arelle/PluginManager.py
+++ b/arelle/PluginManager.py
@@ -59,6 +59,8 @@ class PluginManager:
         self.modulePluginInfos: dict[str, Any] = {}
         self.pluginMethodsForClasses: dict[str, Any] = {}
         self._pluginBase: str = cntlr.pluginDir + os.sep
+        self._entryPointRefCache: list[EntryPointRef] | None = None
+        self._entryPointRefAliasCache: dict[str, list[EntryPointRef]] | None = None
 
         if PLUGIN_TRACE_FILE:
             self.pluginTraceFileLogger = logging.getLogger(__name__)
@@ -316,7 +318,7 @@ class PluginManager:
                     return normalizedPath, None
         # `moduleFilename` did not map to a local filepath or did not normalize to a script
         # Try using `moduleURL` to search for pip-installed entry point
-        entryPointRef = EntryPointRef.get(moduleURL)
+        entryPointRef = EntryPointRef.get(moduleURL, plugin_manager=self)
         if entryPointRef is not None:
             return entryPointRef.moduleFilename, entryPointRef.entryPoint
         return None, None
@@ -694,10 +696,10 @@ class PluginManager:
         :param name: The name to search for
         :return: The module information dictionary, if added. Otherwise, None.
         """
-        entryPointRef = EntryPointRef.get(name)
+        entryPointRef = EntryPointRef.get(name, plugin_manager=self)
         pluginModuleInfo = None
         if entryPointRef:
-            pluginModuleInfo = entryPointRef.createModuleInfo()
+            pluginModuleInfo = entryPointRef.createModuleInfo(plugin_manager=self)
         if not pluginModuleInfo or not pluginModuleInfo.get("name"):
             pluginModuleInfo = self.moduleModuleInfo(moduleURL=name)
         return self.addPluginModuleInfo(pluginModuleInfo)
@@ -769,8 +771,6 @@ class PluginManager:
         return plugin_module_info
 
 
-_entryPointRefCache: list[EntryPointRef] | None = None
-_entryPointRefAliasCache: dict[str, list[EntryPointRef]] | None = None
 _entryPointRefSearchTermEndings = [
     '/__init__.py',
     '.py'
@@ -785,45 +785,52 @@ class EntryPointRef:
     moduleFilename: str | None
     moduleInfo: dict[TypeModuleInfoKey, Any] | None
 
-    def createModuleInfo(self) -> dict[TypeModuleInfoKey, Any] | None:
+    def createModuleInfo(self, plugin_manager: PluginManager | None = None) -> dict[TypeModuleInfoKey, Any] | None:
         """
         Creates a module information dictionary from the entry point ref.
-        :return: A module inforomation dictionary
+        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
+        :return: A module information dictionary
         """
+        pm = plugin_manager or _singleton
+        assert pm is not None
         if self.entryPoint is not None:
-            return moduleModuleInfo(entryPoint=self.entryPoint)
-        return moduleModuleInfo(moduleURL=self.moduleFilename)
+            return pm.moduleModuleInfo(entryPoint=self.entryPoint)
+        return pm.moduleModuleInfo(moduleURL=self.moduleFilename)
 
     @staticmethod
-    def fromEntryPoint(entryPoint: EntryPoint) -> EntryPointRef | None:
+    def fromEntryPoint(entryPoint: EntryPoint, plugin_manager: PluginManager | None = None) -> EntryPointRef | None:
         """
         Given an entry point, retrieves the subset of information from __pluginInfo__ necessary to
         determine if the entry point should be imported as a plugin.
         :param entryPoint:
+        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
         :return:
         """
         pluginUrlFunc = entryPoint.load()
         pluginUrl = pluginUrlFunc()
-        return EntryPointRef.fromFilepath(pluginUrl, entryPoint)
+        return EntryPointRef.fromFilepath(pluginUrl, entryPoint, plugin_manager=plugin_manager)
 
     @staticmethod
-    def fromFilepath(filepath: str, entryPoint: EntryPoint | None = None) -> EntryPointRef | None:
+    def fromFilepath(filepath: str, entryPoint: EntryPoint | None = None, plugin_manager: PluginManager | None = None) -> EntryPointRef | None:
         """
         Given a filepath, retrieves a subset of information from __pluginInfo__ necessary to
         determine if the entry point should be imported as a plugin.
         :param filepath: Path to plugin, can be a directory or .py filepath
         :param entryPoint: Optional entry point information to include in aliases/moduleInfo
+        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
         :return:
         """
-        moduleFilename = _cntlr.webCache.getfilename(filepath)
+        pm = plugin_manager or _singleton
+        assert pm is not None
+        moduleFilename = pm._cntlr.webCache.getfilename(filepath)
         if moduleFilename:
-            moduleFilename = normalizeModuleFilename(moduleFilename)
+            moduleFilename = pm.normalizeModuleFilename(moduleFilename)
         aliases = set()
         if entryPoint:
             aliases.add(entryPoint.name)
         moduleInfo: dict[TypeModuleInfoKey, Any] | None = None
         if moduleFilename:
-            moduleInfo = parsePluginInfo(moduleFilename, moduleFilename, entryPoint)
+            moduleInfo = pm.parsePluginInfo(moduleFilename, moduleFilename, entryPoint)
             if moduleInfo is None:
                 return None
             if "name" in moduleInfo:
@@ -838,23 +845,25 @@ class EntryPointRef:
         )
 
     @staticmethod
-    def discoverAll() -> list[EntryPointRef]:
+    def discoverAll(plugin_manager: PluginManager | None = None) -> list[EntryPointRef]:
         """
         Retrieve all plugin entry points, cached on first run.
+        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
         :return: List of all discovered entry points.
         """
-        global _entryPointRefCache
-        if _entryPointRefCache is None:
-            assert _pluginBase is not None
-            _entryPointRefCache = EntryPointRef._discoverBuiltIn([], _pluginBase) + EntryPointRef._discoverInstalled()
-        return _entryPointRefCache
+        pm = plugin_manager or _singleton
+        assert pm is not None
+        if pm._entryPointRefCache is None:
+            pm._entryPointRefCache = EntryPointRef._discoverBuiltIn([], pm._pluginBase, plugin_manager=pm) + EntryPointRef._discoverInstalled(plugin_manager=pm)
+        return pm._entryPointRefCache
 
     @staticmethod
-    def _discoverBuiltIn(entryPointRefs: list[EntryPointRef], directory: str) -> list[EntryPointRef]:
+    def _discoverBuiltIn(entryPointRefs: list[EntryPointRef], directory: str, plugin_manager: PluginManager | None = None) -> list[EntryPointRef]:
         """
         Recursively retrieve all plugin entry points in the given directory.
         :param entryPointRefs: Working list of entry point refs to append to.
         :param directory: Directory to search for entry points within.
+        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
         :return: List of discovered entry points.
         """
         for fileName in sorted(os.listdir(directory)):
@@ -862,7 +871,7 @@ class EntryPointRef:
                 continue  # Ignore these entries
             filePath = os.path.join(directory, fileName)
             if os.path.isdir(filePath):
-                EntryPointRef._discoverBuiltIn(entryPointRefs, filePath)
+                EntryPointRef._discoverBuiltIn(entryPointRefs, filePath, plugin_manager=plugin_manager)
             if os.path.isfile(filePath) and os.path.basename(filePath).endswith(".py"):
                 # If `filePath` references .py file directly, use it
                 moduleFilePath = filePath
@@ -871,35 +880,37 @@ class EntryPointRef:
                 moduleFilePath = initFilePath
             else:
                 continue
-            entryPointRef = EntryPointRef.fromFilepath(moduleFilePath)
+            entryPointRef = EntryPointRef.fromFilepath(moduleFilePath, plugin_manager=plugin_manager)
             if entryPointRef is not None:
                 entryPointRefs.append(entryPointRef)
         return entryPointRefs
 
     @staticmethod
-    def _discoverInstalled() -> list[EntryPointRef]:
+    def _discoverInstalled(plugin_manager: PluginManager | None = None) -> list[EntryPointRef]:
         """
         Retrieve all installed plugin entry points.
+        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
         :return: List of all discovered entry points.
         """
         entryPoints = list(entry_points(group='arelle.plugin'))
         entryPointRefs = []
         for entryPoint in entryPoints:
-            entryPointRef = EntryPointRef.fromEntryPoint(entryPoint)
+            entryPointRef = EntryPointRef.fromEntryPoint(entryPoint, plugin_manager=plugin_manager)
             if entryPointRef is not None:
                 entryPointRefs.append(entryPointRef)
         return entryPointRefs
 
     @staticmethod
-    def get(search: str) -> EntryPointRef | None:
+    def get(search: str, plugin_manager: PluginManager | None = None) -> EntryPointRef | None:
         """
         Retrieve an entry point ref with a matching name or alias.
         May return None of no matches are found.
         Throws an exception if multiple entry point refs match the search term.
         :param search: Only retrieve entry point matching the given search text.
+        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
         :return: Matching entry point ref, if found.
         """
-        entryPointRefs = EntryPointRef.search(search)
+        entryPointRefs = EntryPointRef.search(search, plugin_manager=plugin_manager)
         if entryPointRefs is None:
             return None
         elif len(entryPointRefs) == 0:
@@ -927,23 +938,25 @@ class EntryPointRef:
             return search.lower()
 
     @staticmethod
-    def search(search: str) -> list[EntryPointRef] | None:
+    def search(search: str, plugin_manager: PluginManager | None = None) -> list[EntryPointRef] | None:
         """
         Retrieve entry point module information matching provided search text.
         A map of aliases to matching entry points is cached on the first run.
         :param search: Only retrieve entry points matching the given search text.
+        :param plugin_manager: PluginManager instance. Defaults to module-level _singleton.
         :return: List of matching module infos.
         """
-        global _entryPointRefAliasCache
-        if _entryPointRefAliasCache is None:
-            entryPointRefAliasCache = defaultdict(list)
-            entryPointRefs = EntryPointRef.discoverAll()
+        pm = plugin_manager or _singleton
+        assert pm is not None
+        if pm._entryPointRefAliasCache is None:
+            entryPointRefAliasCache: dict[str, list[EntryPointRef]] = defaultdict(list)
+            entryPointRefs = EntryPointRef.discoverAll(plugin_manager=pm)
             for entryPointRef in entryPointRefs:
                 for alias in entryPointRef.aliases:
                     entryPointRefAliasCache[alias].append(entryPointRef)
-            _entryPointRefAliasCache = entryPointRefAliasCache
+            pm._entryPointRefAliasCache = entryPointRefAliasCache
         search = EntryPointRef._normalizePluginSearchTerm(search)
-        return _entryPointRefAliasCache.get(search, [])
+        return pm._entryPointRefAliasCache.get(search, [])
 
 
 # ---------------------------------------------------------------------------
@@ -960,6 +973,7 @@ _SINGLETON_ATTRS = frozenset({
     "pluginJsonFile", "pluginConfig", "pluginConfigChanged",
     "pluginTraceFileLogger", "modulePluginInfos", "pluginMethodsForClasses",
     "_cntlr", "_pluginBase",
+    "_entryPointRefCache", "_entryPointRefAliasCache",
 })
 
 

--- a/arelle/Validate.py
+++ b/arelle/Validate.py
@@ -24,7 +24,6 @@ from arelle.ModelObject import ModelObject
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelTestcaseObject import testcaseVariationsByTarget, ModelTestcaseVariation
 from arelle.ModelValue import (qname, QName)
-from arelle.PluginManager import pluginClassMethods
 from arelle.packages.report.DetectReportPackage import isReportPackageExtension
 from arelle.rendering import RenderingEvaluator
 from arelle.utils.EntryPointDetection import filesourceEntrypointFiles
@@ -169,7 +168,7 @@ class Validate:
                             entrypoints = filesourceEntrypointFiles(filesource)
                             if entrypoints:
                                 # resolve an IXDS in entrypoints
-                                for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ArchiveIxds"):
+                                for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelTestcaseVariation.ArchiveIxds"):
                                     pluginXbrlMethod(self, filesource,entrypoints)
                                 filesource.select(entrypoints[0].get("file", None) )
                         except Exception as err:
@@ -178,7 +177,7 @@ class Validate:
                                 modelXbrl=self.modelXbrl, instance=rssItemUrl, error=err)
                             continue # don't try to load this entry URL
                     modelXbrl = ModelXbrl.load(self.modelXbrl.modelManager, filesource, _("validating"), rssItem=rssItem, errorCaptureLevel=errorCaptureLevel)
-                for pluginXbrlMethod in pluginClassMethods("RssItem.Xbrl.Loaded"):
+                for pluginXbrlMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("RssItem.Xbrl.Loaded"):
                     pluginXbrlMethod(modelXbrl, {}, rssItem)
                 if getattr(rssItem, "doNotProcessRSSitem", False) or modelXbrl.modelDocument is None:
                     modelXbrl.close()
@@ -187,7 +186,7 @@ class Validate:
                 self.instValidator.close()
                 rssItem.setResults(modelXbrl)
                 self.modelXbrl.modelManager.viewModelObject(self.modelXbrl, rssItem.objectId())
-                for pluginXbrlMethod in pluginClassMethods("Validate.RssItem"):
+                for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Validate.RssItem"):
                     pluginXbrlMethod(self, modelXbrl, rssItem)
                 modelXbrl.close()
             except Exception as err:
@@ -385,7 +384,7 @@ class Validate:
                 if newSourceFileSource:
                     sourceFileSource.close()
                 _rptPkgIxdsOptions = {}
-                for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ReportPackageIxdsOptions"):
+                for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelTestcaseVariation.ReportPackageIxdsOptions"):
                     pluginXbrlMethod(self, _rptPkgIxdsOptions)
                 reportPackageErrors = False
                 if (filesource.isReportPackage or self.modelXbrl.modelManager.validateAllFilesAsReportPackages) and not _rptPkgIxdsOptions:
@@ -413,7 +412,7 @@ class Validate:
                             )
                             if entrypoints:
                                 # resolve an IXDS in entrypoints
-                                for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ArchiveIxds"):
+                                for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelTestcaseVariation.ArchiveIxds"):
                                     pluginXbrlMethod(self, filesource,entrypoints)
                                 for entrypoint in entrypoints:
                                     filesource.select(entrypoint.get("file", None))
@@ -440,7 +439,7 @@ class Validate:
                                 self.modelXbrl.modelManager.validateAllFilesAsTaxonomyPackages,
                                 errors=preLoadingErrors
                             )
-                            for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ArchiveIxds"):
+                            for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelTestcaseVariation.ArchiveIxds"):
                                 pluginXbrlMethod(self, filesource, entrypoints)
                             for entrypoint in entrypoints:
                                 filesource.select(entrypoint.get("file", None))
@@ -455,7 +454,7 @@ class Validate:
                 else:
                     if _rptPkgIxdsOptions and filesource.isTaxonomyPackage:
                         # Legacy ESEF conformance suite logic.
-                        for pluginXbrlMethod in pluginClassMethods("ModelTestcaseVariation.ReportPackageIxds"):
+                        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ModelTestcaseVariation.ReportPackageIxds"):
                                 filesource.select(pluginXbrlMethod(filesource, **_rptPkgIxdsOptions))
                     if len(loadedModels) == 0:
                         modelXbrl = ModelXbrl.load(self.modelXbrl.modelManager,
@@ -497,17 +496,17 @@ class Validate:
                 _hasFormulae = model.hasFormulae
                 model.hasFormulae = False
                 try:
-                    for pluginXbrlMethod in pluginClassMethods("TestcaseVariation.Xbrl.Loaded"):
+                    for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("TestcaseVariation.Xbrl.Loaded"):
                         pluginXbrlMethod(self.modelXbrl, model, modelTestcaseVariation)
                     self.instValidator.validate(model, parameters)
-                    for pluginXbrlMethod in pluginClassMethods("TestcaseVariation.Xbrl.Validated"):
+                    for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("TestcaseVariation.Xbrl.Validated"):
                         pluginXbrlMethod(self.modelXbrl, model)
                 except Exception as err:
                     model.error("exception:" + type(err).__name__,
                         _("Testcase variation validation exception: %(error)s, instance: %(instance)s"),
                         modelXbrl=model, instance=model.modelDocument.basename, error=err, exc_info=True)
                 model.hasFormulae = _hasFormulae
-        for pluginXbrlMethod in pluginClassMethods("Validate.Complete"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Validate.Complete"):
             pluginXbrlMethod(self.modelXbrl.modelManager.cntlr, filesource)
         errors = [error for model in loadedModels for error in model.errors]
         reportModelCount = len([
@@ -589,7 +588,7 @@ class Validate:
                     _("Testcase formula variation validation exception: %(error)s, instance: %(instance)s"),
                     modelXbrl=modelXbrl, instance=modelXbrl.modelDocument.basename, error=err, exc_info=True)
         if modelTestcaseVariation.resultIsInfoset and self.modelXbrl.modelManager.validateInfoset:
-            for pluginXbrlMethod in pluginClassMethods("Validate.Infoset"):
+            for pluginXbrlMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Validate.Infoset"):
                 pluginXbrlMethod(modelXbrl, modelTestcaseVariation.resultInfosetUri)
             infoset = ModelXbrl.load(self.modelXbrl.modelManager,
                                         modelTestcaseVariation.resultInfosetUri,
@@ -610,7 +609,7 @@ class Validate:
             # diff (or generate) table infoset
             resultTableUri = modelXbrl.modelManager.cntlr.webCache.normalizeUrl(modelTestcaseVariation.resultTableUri, baseForElement)
             if not any(alternativeValidation(modelXbrl, resultTableUri)
-                        for alternativeValidation in pluginClassMethods("Validate.TableInfoset")):
+                        for alternativeValidation in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Validate.TableInfoset")):
                 try:
                     ViewFileRenderedLayout.viewRenderedLayout(modelXbrl, resultTableUri, diffToFile=True)  # false to save infoset files
                 except Exception as err:
@@ -619,7 +618,7 @@ class Validate:
                         modelXbrl=modelXbrl, instance=modelXbrl.modelDocument.basename, error=err, exc_info=True)
         self.instValidator.close()
         extraErrors = []
-        for pluginXbrlMethod in pluginClassMethods("TestcaseVariation.Validated"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("TestcaseVariation.Validated"):
             pluginXbrlMethod(self.modelXbrl, modelXbrl, extraErrors, inputDTSes)
         self.determineTestStatus(modelTestcaseVariation, [e for inputDTSlist in inputDTSes.values() for inputDTS in inputDTSlist for e in inputDTS.errors] + extraErrors) # include infoset errors in status
         if modelXbrl.formulaOutputInstance and self.noErrorCodes(modelTestcaseVariation.actual):

--- a/arelle/ValidateFileSource.py
+++ b/arelle/ValidateFileSource.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from arelle import PluginManager, PackageManager
+from arelle import PackageManager
 from arelle.packages.report.ReportPackageValidator import ReportPackageValidator
 
 if TYPE_CHECKING:
@@ -20,7 +20,7 @@ class ValidateFileSource:
         self._filesource = filesource
 
     def validate(self, forceValidateAsReportPackages: bool = False, forceValidateAsTaxonomyPackage: bool = False, errors: list[str] | None = None) -> None:
-        for pluginXbrlMethod in PluginManager.pluginClassMethods("Validate.FileSource"):
+        for pluginXbrlMethod in self._cntrl.pluginManager.pluginClassMethods("Validate.FileSource"):
             pluginXbrlMethod(self._cntrl, self._filesource)
         if self._filesource.isReportPackage or forceValidateAsReportPackages:
             rpValidator = ReportPackageValidator(self._filesource)

--- a/arelle/ValidateXbrl.py
+++ b/arelle/ValidateXbrl.py
@@ -16,7 +16,6 @@ from arelle.ModelDtsObject import ModelConcept
 from arelle.ModelInstanceObject import ModelContext, ModelDimensionValue, ModelFact, ModelInlineFact
 from arelle.ModelValue import qname
 from arelle.ModelXbrl import ModelXbrl
-from arelle.PluginManager import pluginClassMethods
 from arelle.ValidateXbrlCalcs import inferredDecimals
 from arelle.XbrlConst import (ixbrlAll, dtrNoDecimalsItemTypes, dtrPrefixedContentItemTypes, dtrPrefixedContentTypes,
                               dtrSQNameItemTypes, dtrSQNameTypes,  dtrSQNamesItemTypes, dtrSQNamesTypes, baseXbrliTypes)
@@ -113,7 +112,7 @@ class ValidateXbrl:
         self.validateDuplicateFacts = modelXbrl.modelManager.validateDuplicateFacts
         self._pluginData: dict[str, PluginData] = {}
 
-        for pluginXbrlMethod in pluginClassMethods("Validate.XBRL.Start"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Validate.XBRL.Start"):
             pluginXbrlMethod(self, parameters)
 
         # xlink validation
@@ -395,7 +394,7 @@ class ValidateXbrl:
                 ValidateXbrlDimensions.checkConcept(self, concept)
         modelXbrl.profileStat(_("validateConcepts"))
 
-        for pluginXbrlMethod in pluginClassMethods("Validate.XBRL.Finally"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Validate.XBRL.Finally"):
             pluginXbrlMethod(self)
 
         if modelXbrl.loadedFromOIM or modelXbrl.modelManager.validateXmlOim:
@@ -562,7 +561,7 @@ class ValidateXbrl:
                                      # block executing formulas when validating if hasFormula is False (e.g., --formula=none)
                                      compileOnly=modelXbrl.modelRenderingTables and not modelXbrl.hasFormulae)
 
-        for pluginXbrlMethod in pluginClassMethods("Validate.Finally"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Validate.Finally"):
             pluginXbrlMethod(self)
 
         modelXbrl.modelManager.showStatus(_("ready"), 2000)

--- a/arelle/ValidateXbrlDTS.py
+++ b/arelle/ValidateXbrlDTS.py
@@ -11,7 +11,6 @@ from arelle.ModelDocumentType import ModelDocumentType
 from arelle.ModelRelationshipSet import baseSetRelationship
 from arelle.ModelObject import ModelObject, ModelComment
 from arelle.ModelValue import qname
-from arelle.PluginManager import pluginClassMethods
 from arelle.XhtmlValidate import ixMsgCode
 from lxml import etree
 from collections import defaultdict, deque
@@ -318,7 +317,7 @@ def checkDTS(val: ValidateXbrl, modelDocument: ModelDocument, checkedModelDocume
                         modelXbrl=modelDocument, encoding=val.documentTypeEncoding,
                         metaContentTypeEncoding=val.metaContentTypeEncoding)
             if val.validateSBRNL:
-                for pluginXbrlMethod in pluginClassMethods("Validate.SBRNL.DTS.document"):
+                for pluginXbrlMethod in val.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Validate.SBRNL.DTS.document"):
                     pluginXbrlMethod(val, modelDocument)
             del val.valUsedPrefixes
             del val.schemaRoleTypes
@@ -330,7 +329,7 @@ def checkDTS(val: ValidateXbrl, modelDocument: ModelDocument, checkedModelDocume
             # validate base taxonomy documents. Although Arelle now validates all documents, it retains this logic for
             # the plugin hook to prevent running validation rules intended solely for extension taxonomy documents
             # against base taxonomy documents.
-            for pluginXbrlMethod in pluginClassMethods("Validate.XBRL.DTS.document"):
+            for pluginXbrlMethod in val.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Validate.XBRL.DTS.document"):
                 pluginXbrlMethod(val, modelDocument, isFilingDocument)
 
     val.roleRefURIs = None

--- a/arelle/ViewWinRssFeed.py
+++ b/arelle/ViewWinRssFeed.py
@@ -8,7 +8,6 @@ except ImportError:
     from ttk import *
 import os
 from arelle import (ViewWinTree, ModelDocument)
-from arelle.PluginManager import pluginClassMethods
 
 def viewRssFeed(modelXbrl, tabWin):
     view = ViewRssFeed(modelXbrl, tabWin)
@@ -80,7 +79,7 @@ class ViewRssFeed(ViewWinTree.ViewTree):
         import webbrowser
         filingMenu = Menu(self.viewFrame, tearoff=0)
         filingMenu.add_command(label=_("Open Instance Document"), underline=0, command=self.openInstance)
-        for pluginMenuExtender in pluginClassMethods("RssFeed.Menu.Filing"):
+        for pluginMenuExtender in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("RssFeed.Menu.Filing"):
             pluginMenuExtender(self, filingMenu)
 
         if event is not None:

--- a/arelle/WatchRss.py
+++ b/arelle/WatchRss.py
@@ -8,7 +8,6 @@ from arelle import (ModelXbrl, XmlUtil, ModelVersReport, XbrlConst, ModelDocumen
 from arelle.formula import ValidateFormula
 from arelle.FileSource import openFileSource
 from arelle.ModelValue import (qname, QName)
-from arelle.PluginManager import pluginClassMethods
 from arelle.UrlUtil import parseRfcDatetime
 import datetime
 
@@ -111,7 +110,7 @@ class WatchRss:
                 rssWatchOptions.get("validateFormulaAssertions") or
                 rssWatchOptions.get("alertMatchedFactText") or
                 any(pluginXbrlMethod(rssWatchOptions)
-                    for pluginXbrlMethod in pluginClassMethods("RssWatch.HasWatchAction"))
+                    for pluginXbrlMethod in self.cntlr.pluginManager.pluginClassMethods("RssWatch.HasWatchAction"))
                 ):
                 # form keys in ascending order of pubdate
                 pubDateRssItems = []
@@ -146,7 +145,7 @@ class WatchRss:
                                             form=rssItem.formType, date=rssItem.filingDate)
                             rssItem.status = "not loadable"
                         else:
-                            for pluginXbrlMethod in pluginClassMethods("RssItem.Xbrl.Loaded"):
+                            for pluginXbrlMethod in self.cntlr.pluginManager.pluginClassMethods("RssItem.Xbrl.Loaded"):
                                 pluginXbrlMethod(modelXbrl, rssWatchOptions, rssItem)
                             # validate schema, linkbase, or instance
                             if self.stopRequested:
@@ -156,7 +155,7 @@ class WatchRss:
                                 self.instValidator.validate(modelXbrl, modelXbrl.modelManager.formulaOptions.typedParameters(modelXbrl.prefixedNamespaces))
                                 if modelXbrl.errors and rssWatchOptions.get("alertValiditionError"):
                                     emailAlert = True
-                            for pluginXbrlMethod in pluginClassMethods("RssWatch.DoWatchAction"):
+                            for pluginXbrlMethod in self.cntlr.pluginManager.pluginClassMethods("RssWatch.DoWatchAction"):
                                 pluginXbrlMethod(modelXbrl, rssWatchOptions, rssItem)
                             # check match expression
                             if matchPattern:

--- a/arelle/WebCache.py
+++ b/arelle/WebCache.py
@@ -38,7 +38,6 @@ except ImportError:
     ssl = None
 
 from arelle.FileSource import SERVER_WEB_CACHE, archiveFilenameParts
-from arelle.PluginManager import pluginClassMethods
 from arelle.UrlUtil import isHttpUrl
 from arelle.Version import __version__
 
@@ -252,9 +251,9 @@ class WebCache:
             _proxyDirFmt = proxyDirFmt(httpProxyTuple)
             # only try ntlm if user and password are provided because passman is needed
             if user and not useOsProxy:
-                for pluginXbrlMethod in pluginClassMethods("Proxy.HTTPAuthenticate"):
+                for pluginXbrlMethod in self.cntlr.pluginManager.pluginClassMethods("Proxy.HTTPAuthenticate"):
                     pluginXbrlMethod(self.cntlr)
-                for pluginXbrlMethod in pluginClassMethods("Proxy.HTTPNtlmAuthHandler"):
+                for pluginXbrlMethod in self.cntlr.pluginManager.pluginClassMethods("Proxy.HTTPNtlmAuthHandler"):
                     HTTPNtlmAuthHandler = pluginXbrlMethod()
                     if HTTPNtlmAuthHandler is not None:
                         self.hasNTLM = True
@@ -473,7 +472,7 @@ class WebCache:
             normalize: bool = False, filenameOnly: bool = False,
             allowTransformation: bool = True) -> str | None:
         if allowTransformation:
-            for pluginXbrlMethod in pluginClassMethods("WebCache.TransformURL"):
+            for pluginXbrlMethod in self.cntlr.pluginManager.pluginClassMethods("WebCache.TransformURL"):
                 url, final = pluginXbrlMethod(self.cntlr, url, base)
                 if final:
                     return url
@@ -744,7 +743,7 @@ class WebCache:
                     if tryWebAuthentication:
                         # check if single signon is requested (on first retry)
                         if retryCount == RETRIEVAL_RETRY_COUNT:
-                            for pluginXbrlMethod in pluginClassMethods("Proxy.HTTPAuthenticate"):
+                            for pluginXbrlMethod in self.cntlr.pluginManager.pluginClassMethods("Proxy.HTTPAuthenticate"):
                                 if pluginXbrlMethod(self.cntlr): # true if succeessful single sign on
                                     retryCount -= 1
                                     break

--- a/arelle/api/Session.py
+++ b/arelle/api/Session.py
@@ -64,8 +64,8 @@ class Session:
         with _session_lock:
             self._check_thread()
             if self._cntlr is not None:
+                self._cntlr.pluginManager.close()
                 self._cntlr.close()
-            PluginManager.close()
 
     def get_log_messages(self) -> list[dict[str, Any]]:
         """
@@ -128,7 +128,8 @@ class Session:
         with _session_lock:
             self._check_thread()
             PackageManager.reset()
-            PluginManager.reset()
+            if self._cntlr is not None:
+                self._cntlr.pluginManager.reset()
             if self._cntlr is None:
                 # Certain options must be passed into the controller constructor to have the intended effect
                 self._cntlr = createCntlrAndPreloadPlugins(

--- a/arelle/api/Session.py
+++ b/arelle/api/Session.py
@@ -110,6 +110,7 @@ class Session:
         responseZipStream: BinaryIO | None = None,
         logHandler: logging.Handler | None = None,
         logFilters: list[logging.Filter] | None = None,
+        logFileName: str | None = None,
     ) -> bool:
         """
         Perform a run using the given options.
@@ -133,6 +134,7 @@ class Session:
             if self._cntlr is None:
                 # Certain options must be passed into the controller constructor to have the intended effect
                 self._cntlr = createCntlrAndPreloadPlugins(
+                    logFileName=logFileName,
                     uiLang=options.uiLang,
                     disablePersistentConfig=options.disablePersistentConfig,
                     arellePluginModules={},

--- a/arelle/archive/plugin/importTestParent.py
+++ b/arelle/archive/plugin/importTestParent.py
@@ -3,7 +3,6 @@ pluginPackages test case
 
 See COPYRIGHT.md for copyright information.
 '''
-from arelle.PluginManager import pluginClassMethods
 from arelle.Version import authorLabel, copyrightLabel
 # . relative import only works inside a package now, see https://www.python.org/dev/peps/pep-0366/
 # following two imports raise system error due to PEP 366 after python 3.4.3
@@ -13,9 +12,9 @@ from arelle.Version import authorLabel, copyrightLabel
 def parentMenuEntender(cntlr, menu):
     menu.add_command(label="Unpackaged Parent exercise descendants", underline=0, command=lambda: parentMenuCommand(cntlr) )
 
-def parentMenuCommand(cntl):
+def parentMenuCommand(cntlr):
     for i in range(1,100):
-        for pluginMethod in pluginClassMethods("Import.Unpackaged.Entry{}".format(i)):
+        for pluginMethod in cntlr.pluginManager.pluginClassMethods("Import.Unpackaged.Entry{}".format(i)):
             pluginMethod()
 
 def parentCommandLineOptionExtender(parser):

--- a/arelle/archive/plugin/packagedImportTest/__init__.py
+++ b/arelle/archive/plugin/packagedImportTest/__init__.py
@@ -4,7 +4,6 @@ pluginPackages test case
 See COPYRIGHT.md for copyright information.
 '''
 from os import path
-from arelle.PluginManager import pluginClassMethods
 from arelle.Version import authorLabel, copyrightLabel
 from . import importTestImported1
 from .importTestImported1 import foo
@@ -12,9 +11,9 @@ from .importTestImported1 import foo
 def parentMenuEntender(cntlr, menu):
     menu.add_command(label="Packaged Parent exercise descendants", underline=0, command=lambda: parentMenuCommand(cntlr) )
 
-def parentMenuCommand(cntl):
+def parentMenuCommand(cntlr):
     for i in range(1,100):
-        for pluginMethod in pluginClassMethods("Import.Packaged.Entry{}".format(i)):
+        for pluginMethod in cntlr.pluginManager.pluginClassMethods("Import.Packaged.Entry{}".format(i)):
             pluginMethod()
 
 def parentCommandLineOptionExtender(parser):

--- a/arelle/archive/plugin/validate/USBestPractices.py
+++ b/arelle/archive/plugin/validate/USBestPractices.py
@@ -4,7 +4,6 @@ See COPYRIGHT.md for copyright information.
 
 # changed from reporting locs to reporting relationships: HF 2020-06-23
 
-from arelle import PluginManager
 from arelle.ModelDtsObject import ModelConcept
 from arelle.ModelValue import qname
 from arelle.Version import copyrightLabel

--- a/arelle/archive/plugin/validate/USSecTagging.py
+++ b/arelle/archive/plugin/validate/USSecTagging.py
@@ -2,7 +2,6 @@
 See COPYRIGHT.md for copyright information.
 '''
 
-from arelle import PluginManager
 from arelle.ModelValue import qname
 from arelle import XbrlConst
 from arelle.Version import copyrightLabel

--- a/arelle/examples/plugin/formulaSuiteConverter.py
+++ b/arelle/examples/plugin/formulaSuiteConverter.py
@@ -14,7 +14,6 @@ from arelle import ModelXbrl, XmlUtil
 from arelle.ModelDocument import Type
 from arelle.ModelValue import qname
 from arelle.ViewUtilFormulae import rootFormulaObjects, formulaObjSortKey
-from arelle.PluginManager import pluginClassMethods
 from arelle.PrototypeDtsObject import PrototypeObject
 from arelle.PythonUtil import attrdict
 from arelle.Version import authorLabel, copyrightLabel
@@ -66,7 +65,7 @@ def convertVariation(cntlr, variationFile, variationElt, inPath, outPath, entryP
                 ref.referringModelObject.qname = QN_SCHEMA_REF
 
     # perform OIM validation on xBRL-XML source instance
-    for pluginXbrlMethod in pluginClassMethods("Validate.XBRL.Finally"):
+    for pluginXbrlMethod in cntlr.pluginManager.pluginClassMethods("Validate.XBRL.Finally"):
         pluginXbrlMethod(doc)
     if any(oimErrPattern.match(err) for err in modelXbrl.errors):
         modelXbrl.error("testSuiteConverter:unconvertableTestcase",
@@ -87,7 +86,7 @@ def convertVariation(cntlr, variationFile, variationElt, inPath, outPath, entryP
     # CntlrCmdLine.Xbrl.Run invokes both saveLoadableOIM for instance and formulaSaver for xf
     options = attrdict(**transformedFiles)
     try:
-        for pluginXbrlMethod in pluginClassMethods("CntlrCmdLine.Xbrl.Run"):
+        for pluginXbrlMethod in cntlr.pluginManager.pluginClassMethods("CntlrCmdLine.Xbrl.Run"):
             pluginXbrlMethod(cntlr, options, modelXbrl)
     except Exception as ex:
         modelXbrl.error("testSuiteConverter:unconvertableTestcase",
@@ -100,7 +99,7 @@ def convertVariation(cntlr, variationFile, variationElt, inPath, outPath, entryP
         options = attrdict(saveLoadableOIM=os.path.join(outPath, resultOutFile))
         convertedFiles[resultInstFile] = resultOutFile
         try:
-            for pluginXbrlMethod in pluginClassMethods("CntlrCmdLine.Xbrl.Run"):
+            for pluginXbrlMethod in cntlr.pluginManager.pluginClassMethods("CntlrCmdLine.Xbrl.Run"):
                 pluginXbrlMethod(cntlr, options, modelXbrl)
         except Exception as ex:
             modelXbrl.error("testSuiteConverter:unconvertableTestcase",

--- a/arelle/examples/plugin/rssSaveOim.py
+++ b/arelle/examples/plugin/rssSaveOim.py
@@ -24,7 +24,6 @@ This plug-in imports the following plug-ins:
 import os
 from arelle import ModelXbrl
 from arelle.FileSource import openFileSource
-from arelle.PluginManager import pluginClassMethods
 from arelle.Version import authorLabel, copyrightLabel
 
 def saveFilingOim(cntlr, zippedUrl, oimFile):
@@ -32,7 +31,7 @@ def saveFilingOim(cntlr, zippedUrl, oimFile):
     modelXbrl = ModelXbrl.load(cntlr.modelManager,
                                openFileSource(zippedUrl, cntlr))
     if modelXbrl is not None:
-        for saveLoadableOIM in pluginClassMethods("SaveLoadableOim.Save"):
+        for saveLoadableOIM in cntlr.pluginManager.pluginClassMethods("SaveLoadableOim.Save"):
             saveLoadableOIM(modelXbrl, oimFile)
             modelXbrl.info("arelle:savedOIM", _("Saved OIM File {}").format(oimFile))
         # check for supplemental instances
@@ -41,7 +40,7 @@ def saveFilingOim(cntlr, zippedUrl, oimFile):
             for supplementalModelXbrl in modelXbrl.supplementalModelXbrls:
                 # use basename for the json file
                 supplementalOimFile = os.path.join(oimFileDir, os.path.splitext(supplementalModelXbrl.basename)[0] + ".json")
-                for saveLoadableOIM in pluginClassMethods("SaveLoadableOim.Save"):
+                for saveLoadableOIM in cntlr.pluginManager.pluginClassMethods("SaveLoadableOim.Save"):
                     saveLoadableOIM(supplementalModelXbrl, supplementalOimFile)
                     modelXbrl.info("arelle:savedOIM",_("Saved OIM File {}").format(supplementalOimFile))
                 supplementalModelXbrl.close()

--- a/arelle/formula/ValidateFormula.py
+++ b/arelle/formula/ValidateFormula.py
@@ -36,7 +36,6 @@ from arelle.ModelRenderingObject import (
     DefnMdlAspectNode,
 )
 from arelle.ModelValue import QName, qname
-from arelle.PluginManager import pluginClassMethods
 from arelle.PythonUtil import normalizeSpace
 from arelle.XmlValidate import validate as xml_validate
 from arelle.formula import XPathContext, XPathParser
@@ -739,7 +738,7 @@ def validate(val, xpathContext=None, parametersOnly=False, statusMsg='', compile
     val.modelXbrl.profileActivity("... instances scopes and setup", minTimeToShow=1.0)
 
     val.modelXbrl.profileStat(_("formulaValidation"))
-    for pluginXbrlMethod in pluginClassMethods("ValidateFormula.Compiled"):
+    for pluginXbrlMethod in val.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ValidateFormula.Compiled"):
         pluginXbrlMethod(val.modelXbrl, xpathContext)
 
     if (
@@ -874,7 +873,7 @@ def validate(val, xpathContext=None, parametersOnly=False, statusMsg='', compile
         val.modelXbrl.formulaOutputInstance = outputXbrlInstance
 
     val.modelXbrl.modelManager.showStatus(_("formulae finished"), 2000)
-    for pluginXbrlMethod in pluginClassMethods("ValidateFormula.Finished"):
+    for pluginXbrlMethod in val.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("ValidateFormula.Finished"):
         pluginXbrlMethod(val)
 
     instanceProducingVariableSets.clear()  # dereference

--- a/arelle/formula/XPathContext.py
+++ b/arelle/formula/XPathContext.py
@@ -36,7 +36,6 @@ from arelle.ModelValue import (
     qname,
 )
 from arelle.ModelXbrl import ModelXbrl
-from arelle.PluginManager import pluginClassMethods
 from arelle.PrototypeDtsObject import PrototypeElementTree, PrototypeObject
 from arelle.PythonUtil import STR_NUM_TYPES
 from arelle.formula.FactAspectsCache import FactAspectsCache
@@ -241,7 +240,7 @@ class XPathContext:
             QName,
             Callable[[XPathContext, OperationDef, ContextItem, ResultStack], ContextItem]
         ] = {}
-        for pluginXbrlMethod in pluginClassMethods("Formula.CustomFunctions"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Formula.CustomFunctions"):
             self.customFunctions.update(pluginXbrlMethod())
 
     def copy(self) -> XPathContext:  # shallow copy (for such as for Table LB table processiong

--- a/arelle/formula/XPathParser.py
+++ b/arelle/formula/XPathParser.py
@@ -39,7 +39,6 @@ from pyparsing import (
 
 from arelle import ModelValue, XbrlConst, XmlUtil
 from arelle.Locale import format_string
-from arelle.PluginManager import pluginClassMethods
 
 if TYPE_CHECKING:
     from arelle.ModelFormulaObject import ModelFormulaResource
@@ -976,7 +975,7 @@ def parse(
     returnProg = None
     pluginCustomFunctionQNames = set()
 
-    for pluginXbrlMethod in pluginClassMethods("Formula.CustomFunctions"):
+    for pluginXbrlMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Formula.CustomFunctions"):
         pluginCustomFunctionQNames.update(pluginXbrlMethod().keys())
 
     # throws ParseException

--- a/arelle/logging/handlers/LogToBufferHandler.py
+++ b/arelle/logging/handlers/LogToBufferHandler.py
@@ -3,7 +3,12 @@ See COPYRIGHT.md for copyright information.
 """
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from arelle.logging.handlers.LogToXmlHandler import LogToXmlHandler
+
+if TYPE_CHECKING:
+    from arelle.Cntlr import Cntlr
 
 
 class LogToBufferHandler(LogToXmlHandler):
@@ -13,8 +18,8 @@ class LogToBufferHandler(LogToXmlHandler):
     A log handler that writes log entries to a memory buffer for later retrieval (to a string) in XML, JSON, or text lines,
     usually for return to a web service or web page call.
     """
-    def __init__(self) -> None:
-        super(LogToBufferHandler, self).__init__()
+    def __init__(self, cntlr: Cntlr) -> None:
+        super(LogToBufferHandler, self).__init__(cntlr)
 
     def flush(self) -> None:
         pass # do nothing -- overrides LogToXmlHandler's flush

--- a/arelle/logging/handlers/LogToXmlHandler.py
+++ b/arelle/logging/handlers/LogToXmlHandler.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 import json
 import logging
 import sys
+from typing import TYPE_CHECKING
 
-from arelle import PluginManager
 from arelle.logging.handlers.LogHandlerWithXml import LogHandlerWithXml
+
+if TYPE_CHECKING:
+    from arelle.Cntlr import Cntlr
 
 
 class LogToXmlHandler(LogHandlerWithXml):
@@ -18,17 +21,20 @@ class LogToXmlHandler(LogHandlerWithXml):
     A log handler that writes log entries to named XML file (utf-8 encoded) upon closing the application.
     """
     logRecordBuffer: list[logging.LogRecord]
+    cntlr: Cntlr
     filename: str | None
     filemode: str
     htmlTitle: str = "Arelle Message Log" # may be customized in plugin startup
 
     def __init__(
             self,
+            cntlr: Cntlr,
             filename: str | None = None,
             mode: str = 'w',
             logXmlMaxAttributeLength: int | None = None
     ) -> None:
         super(LogToXmlHandler, self).__init__(logXmlMaxAttributeLength=logXmlMaxAttributeLength)
+        self.cntlr = cntlr
         self.filename = filename # may be none if buffer is retrieved by get methods below and not written anywhere
         self.logRecordBuffer = []
         self.filemode = mode
@@ -36,7 +42,7 @@ class LogToXmlHandler(LogHandlerWithXml):
     def flush(self) -> None:
         # Note to developers: breakpoints in this method don't work, please debug with print statements
         securityIsActive = securityHasWritten = False
-        for pluginMethod in PluginManager.pluginClassMethods("Security.Crypt.IsActive"):
+        for pluginMethod in self.cntlr.pluginManager.pluginClassMethods("Security.Crypt.IsActive"):
             securityIsActive = pluginMethod(self) # must be active for the cntlr object to effect log writing
         if self.filename == "logToStdOut.xml":
             print('<?xml version="1.0" encoding="utf-8"?>')
@@ -55,7 +61,7 @@ class LogToXmlHandler(LogHandlerWithXml):
             if self.filename.endswith(".xml"):
                 # print ("filename=" + self.filename)
                 if securityIsActive:
-                    for pluginMethod in PluginManager.pluginClassMethods("Security.Crypt.Write"):
+                    for pluginMethod in self.cntlr.pluginManager.pluginClassMethods("Security.Crypt.Write"):
                         securityHasWritten = pluginMethod(self, self.filename,
                                                           '<?xml version="1.0" encoding="utf-8"?>\n<log>\n' +
                                                           ''.join(self.recordToXml(logRec) for logRec in self.logRecordBuffer) +
@@ -68,14 +74,14 @@ class LogToXmlHandler(LogHandlerWithXml):
                         fh.write('</log>\n')
             elif self.filename.endswith(".json"):
                 if securityIsActive:
-                    for pluginMethod in PluginManager.pluginClassMethods("Security.Crypt.Write"):
+                    for pluginMethod in self.cntlr.pluginManager.pluginClassMethods("Security.Crypt.Write"):
                         securityHasWritten = pluginMethod(self, self.filename, self.getJson())
                 if not securityHasWritten:
                     with open(self.filename, self.filemode, encoding='utf-8') as fh:
                         fh.write(self.getJson())
             elif self.filename.endswith(".html"):
                 if securityIsActive:
-                    for pluginMethod in PluginManager.pluginClassMethods("Security.Crypt.Write"):
+                    for pluginMethod in self.cntlr.pluginManager.pluginClassMethods("Security.Crypt.Write"):
                         securityHasWritten = pluginMethod(self, self.filename, self.getHtml())
                 if not securityHasWritten:
                     with open(self.filename, self.filemode, encoding='utf-8') as fh:
@@ -94,7 +100,7 @@ class LogToXmlHandler(LogHandlerWithXml):
                               file=_file)
             else:
                 if securityIsActive:
-                    for pluginMethod in PluginManager.pluginClassMethods("Security.Crypt.Write"):
+                    for pluginMethod in self.cntlr.pluginManager.pluginClassMethods("Security.Crypt.Write"):
                         securityHasWritten = pluginMethod(self, self.filename,
                                                           ''.join(self.format(logRec) + "\n" for logRec in self.logRecordBuffer))
                 if not securityHasWritten:
@@ -181,7 +187,7 @@ class LogToXmlHandler(LogHandlerWithXml):
         ]
         if self.logRecordBuffer:
             for logRec in self.logRecordBuffer:
-                if all(p(logRec) for p in PluginManager.pluginClassMethods("Cntlr.Log.RecFilter.Html")):
+                if all(p(logRec) for p in self.cntlr.pluginManager.pluginClassMethods("Cntlr.Log.RecFilter.Html")):
                     html.append(self.recordToHtml(logRec))
             if clearLogBuffer:
                 self.clearLogBuffer()

--- a/arelle/oim/Load.py
+++ b/arelle/oim/Load.py
@@ -22,7 +22,6 @@ from arelle import (ModelDocument, ModelXbrl, PackageManager, UrlUtil,
                     ValidateXbrlDimensions, XbrlConst, XmlUtil, XmlValidate)
 from arelle.ModelValue import (DATETIME, dateTime, dayTimeDuration, qname,
                                yearMonthDuration)
-from arelle.PluginManager import pluginClassMethods
 from arelle.PrototypeInstanceObject import DimValuePrototype
 from arelle.PythonUtil import attrdict, isLegacyAbs, strTruncate
 from arelle.typing import TypeGetText
@@ -922,7 +921,7 @@ def _loadFromOIM(cntlr, error, warning, modelXbrl, oimFile, mappedUri):
                             "JSON error while %(action)s, %(file)s \"metadata\" worksheet, error %(error)s",
                             file=filepath, action=currentAction, error=ex)
             # allow report setup or extension objects processing
-            for pluginXbrlMethod in pluginClassMethods("LoadFromOim.DocumentSetup"):
+            for pluginXbrlMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("LoadFromOim.DocumentSetup"):
                 pluginXbrlMethod(modelXbrl, oimObject, oimFile)
             # identify document type (JSON or CSV)
             documentInfo = jsonGet(oimObject, "documentInfo", {})

--- a/arelle/plugin/inlineXbrlDocumentSet.py
+++ b/arelle/plugin/inlineXbrlDocumentSet.py
@@ -136,7 +136,6 @@ from arelle.ModelDocument import ModelDocument, ModelDocumentReference, Type, cr
 from arelle.ModelInstanceObject import ModelInlineFootnote
 from arelle.ModelObject import ModelObject
 from arelle.ModelValue import INVALIDixVALUE, qname
-from arelle.PluginManager import pluginClassMethods
 from arelle.PrototypeDtsObject import ArcPrototype, LocPrototype
 from arelle.PythonUtil import attrdict, isLegacyAbs
 from arelle.RuntimeOptions import RuntimeOptions
@@ -612,7 +611,7 @@ def runSaveTargetDocumentMenuCommand(
         responseZipStream: BinaryIO | None = None,
         deduplicationType: DeduplicationType | None = None):
     # skip if another class handles saving (e.g., EDGAR/render)
-    if saveTargetInstanceOverriden(deduplicationType):
+    if saveTargetInstanceOverriden(cntlr, deduplicationType):
         return
     # save DTS menu item has been invoked
     if (cntlr.modelManager is None or
@@ -807,14 +806,15 @@ def filingStart(cntlr, entrypointFiles, inlineTarget):
                     entrypointFile["file"] = docsetSurrogatePath + IXDS_DOC_SEPARATOR.join(_files)
 
 
-def saveTargetInstanceOverriden(deduplicationType: DeduplicationType | None) -> bool:
+def saveTargetInstanceOverriden(cntlr, deduplicationType: DeduplicationType | None) -> bool:
     """
     Checks if another plugin implements instance extraction, and throws an exception
     if the provided arguments are not compatible.
+    :param cntlr: The controller for plugin manager access.
     :param deduplicationType: The deduplication type to be used, if set.
     :return: True if instance extraction is overridden by another plugin.
     """
-    for pluginXbrlMethod in pluginClassMethods('InlineDocumentSet.SavesTargetInstance'):
+    for pluginXbrlMethod in cntlr.pluginManager.pluginClassMethods('InlineDocumentSet.SavesTargetInstance'):
         if pluginXbrlMethod():
             if deduplicationType is not None:
                 raise RuntimeError(_('Deduplication is enabled but could not be performed because instance '
@@ -827,7 +827,7 @@ def commandLineXbrlRun(cntlr, options: RuntimeOptions, modelXbrl, *args, **kwarg
     deduplicationTypeArg = getattr(options, "deduplicateIxbrlFacts", None)
     deduplicationType = None if deduplicationTypeArg is None else DeduplicationType(deduplicationTypeArg)
     # skip if another class handles saving (e.g., EDGAR/render)
-    if saveTargetInstanceOverriden(deduplicationType):
+    if saveTargetInstanceOverriden(cntlr, deduplicationType):
         return
     # extend XBRL-loaded run processing for this option
     if getattr(options, "saveTargetInstance", False) or getattr(options, "saveTargetFiling", False):
@@ -956,7 +956,7 @@ def selectTargetDocument(modelXbrl, modelIxdsDocument, **kwargs):
     if not hasattr(modelXbrl, "ixdsTarget"): # DTS discoverey deferred until all ix docs loaded
         # isolate any documents to separate IXDSes according to authority submission rules
         modelXbrl.targetIXDSesToLoad = [] # [[target,[ixdsHtmlElements], ...]
-        for pluginXbrlMethod in pluginClassMethods('InlineDocumentSet.IsolateSeparateIXDSes'):
+        for pluginXbrlMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods('InlineDocumentSet.IsolateSeparateIXDSes'):
             separateIXDSesHtmlElements = pluginXbrlMethod(modelXbrl, modelIxdsDocument, **kwargs)
             if len(separateIXDSesHtmlElements) > 1: # [[ixdsHtml1, ixdsHtml2], [ixdsHtml3...] ...]
                 for separateIXDSHtmlElements in separateIXDSesHtmlElements[1:]:

--- a/arelle/plugin/streamingExtensions.py
+++ b/arelle/plugin/streamingExtensions.py
@@ -24,7 +24,6 @@ from arelle.ModelDocument import ModelDocument, Type
 from arelle.ModelObjectFactory import parser
 from arelle.ModelObject import ModelObject
 from arelle.ModelInstanceObject import ModelFact
-from arelle.PluginManager import pluginClassMethods
 from arelle.Validate import Validate
 from arelle.Version import authorLabel, copyrightLabel
 from arelle.HashUtil import md5hash, Md5Sum
@@ -235,7 +234,7 @@ def streamingExtensionsLoader(modelXbrl, mappedUri, filepath, *args, **kwargs):
     logSyntaxErrors(instInfoContext)
     del instInfoContext # dereference
 
-    for pluginMethod in pluginClassMethods("Streaming.BlockStreaming"):
+    for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.BlockStreaming"):
         _blockingPluginName = pluginMethod(modelXbrl)
         if _blockingPluginName: # name of blocking plugin is returned
             modelXbrl.error("streamingExtensions:incompatiblePlugIn",
@@ -261,9 +260,9 @@ def streamingExtensionsLoader(modelXbrl, mappedUri, filepath, *args, **kwargs):
     footnoteBuffer = []
     footnoteLinksToDrop = []
 
-    _streamingFactsPlugin = any(True for pluginMethod in pluginClassMethods("Streaming.Facts"))
+    _streamingFactsPlugin = any(True for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.Facts"))
     _streamingValidateFactsPlugin = (_streamingExtensionsValidate and
-                                     any(True for pluginMethod in pluginClassMethods("Streaming.ValidateFacts")))
+                                     any(True for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.ValidateFacts")))
 
     ''' this is very much slower than iterparse
     class modelLoaderTarget():
@@ -313,7 +312,7 @@ def streamingExtensionsLoader(modelXbrl, mappedUri, filepath, *args, **kwargs):
                     else: # need default dimensions
                         ValidateXbrlDimensions.loadDimensionDefaults(modelXbrl)
                 elif not self.beforeInstanceStream and self.beforeStartStreamingPlugin:
-                    for pluginMethod in pluginClassMethods("Streaming.Start"):
+                    for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.Start"):
                         pluginMethod(modelXbrl)
                     self.beforeStartStreamingPlugin = False
             return mdlObj
@@ -375,7 +374,7 @@ def streamingExtensionsLoader(modelXbrl, mappedUri, filepath, *args, **kwargs):
                             factsToCheck = modelXbrl.facts.copy()
                             factsHaveBeenProcessed = True
                             # can block facts deletion if required data not yet available, such as numeric unit for DpmDB
-                            for pluginMethod in pluginClassMethods("Streaming.ValidateFacts"):
+                            for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.ValidateFacts"):
                                 if not pluginMethod(modelXbrl, factsToCheck):
                                     factsHaveBeenProcessed = False
                             if factsHaveBeenProcessed:
@@ -399,7 +398,7 @@ def streamingExtensionsLoader(modelXbrl, mappedUri, filepath, *args, **kwargs):
                     # check remaining footnote refs
                     for footnoteLink in footnoteBuffer:
                         checkFootnoteHrefs(modelXbrl, footnoteLink)
-                    for pluginMethod in pluginClassMethods("Streaming.Finish"):
+                    for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.Finish"):
                         pluginMethod(modelXbrl)
             elif ns == XbrlConst.link:
                 if ln == "footnoteLink":
@@ -446,7 +445,7 @@ def streamingExtensionsLoader(modelXbrl, mappedUri, filepath, *args, **kwargs):
                             factsToCheck = modelXbrl.facts.copy()
                             factsHaveBeenProcessed = True
                             # can block facts deletion if required data not yet available, such as numeric unit for DpmDB
-                            for pluginMethod in pluginClassMethods("Streaming.ValidateFacts"):
+                            for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.ValidateFacts"):
                                 if not pluginMethod(modelXbrl, factsToCheck):
                                     factsHaveBeenProcessed = False
                             if factsHaveBeenProcessed:
@@ -570,7 +569,7 @@ def streamingExtensionsLoader(modelXbrl, mappedUri, filepath, *args, **kwargs):
                         else: # need default dimensions
                             ValidateXbrlDimensions.loadDimensionDefaults(modelXbrl)
                 elif not beforeInstanceStream and beforeStartStreamingPlugin:
-                    for pluginMethod in pluginClassMethods("Streaming.Start"):
+                    for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.Start"):
                         pluginMethod(modelXbrl)
                     beforeStartStreamingPlugin = False
         elif event == "end":
@@ -628,10 +627,10 @@ def streamingExtensionsLoader(modelXbrl, mappedUri, filepath, *args, **kwargs):
                             factsToCheck = modelXbrl.facts.copy()
                             # can block facts deletion if required data not yet available, such as numeric unit for DpmDB
                             if _streamingValidateFactsPlugin:
-                                for pluginMethod in pluginClassMethods("Streaming.ValidateFacts"):
+                                for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.ValidateFacts"):
                                     pluginMethod(instValidator, factsToCheck)
                             if _streamingFactsPlugin:
-                                for pluginMethod in pluginClassMethods("Streaming.Facts"):
+                                for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.Facts"):
                                     pluginMethod(modelXbrl, factsToCheck)
                             for fact in factsToCheck:
                                 dropFact(modelXbrl, fact, modelXbrl.facts)
@@ -675,10 +674,10 @@ def streamingExtensionsLoader(modelXbrl, mappedUri, filepath, *args, **kwargs):
                                                 _("Invalid sum-of-md5s %(sumOfMd5)s"),
                                                 modelObject=modelXbrl, sumOfMd5=_matchGroups[1])
                     if _streamingValidateFactsPlugin:
-                        for pluginMethod in pluginClassMethods("Streaming.ValidateFinish"):
+                        for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.ValidateFinish"):
                             pluginMethod(instValidator)
                     if _streamingFactsPlugin:
-                        for pluginMethod in pluginClassMethods("Streaming.Finish"):
+                        for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.Finish"):
                             pluginMethod(modelXbrl)
             elif ns == XbrlConst.link:
                 if ln in ("schemaRef", "linkbaseRef"):
@@ -724,10 +723,10 @@ def streamingExtensionsLoader(modelXbrl, mappedUri, filepath, *args, **kwargs):
                             factsToCheck = modelXbrl.facts.copy()
                             # can block facts deletion if required data not yet available, such as numeric unit for DpmDB
                             if _streamingValidateFactsPlugin:
-                                for pluginMethod in pluginClassMethods("Streaming.ValidateFacts"):
+                                for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.ValidateFacts"):
                                     pluginMethod(instValidator, factsToCheck)
                             if _streamingFactsPlugin:
-                                for pluginMethod in pluginClassMethods("Streaming.Facts"):
+                                for pluginMethod in modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("Streaming.Facts"):
                                     pluginMethod(modelXbrl, factsToCheck)
                             for fact in factsToCheck:
                                 dropFact(modelXbrl, fact, modelXbrl.facts)

--- a/arelle/plugin/validate/EBA/__init__.py
+++ b/arelle/plugin/validate/EBA/__init__.py
@@ -5,7 +5,6 @@ EBA (2.3), EIOPA (2.0.0) Filing Rules Validation
 """
 import os, sys
 import regex as re
-from arelle import PluginManager
 from arelle import XbrlConst, XmlUtil, UrlUtil, LeiUtil
 from arelle.ModelDocumentType import ModelDocumentType
 from arelle.HashUtil import md5hash, Md5Sum

--- a/arelle/plugin/xbrlDB/XbrlOpenSqlDB.py
+++ b/arelle/plugin/xbrlDB/XbrlOpenSqlDB.py
@@ -49,7 +49,6 @@ from arelle.ModelDocument import ModelDocument
 from arelle.ModelObject import ModelObject
 from arelle.ModelValue import qname, QName, dateTime, DATETIME
 from arelle.ModelRelationshipSet import ModelRelationshipSet
-from arelle.PluginManager import pluginClassMethods
 from arelle.PrototypeInstanceObject import DimValuePrototype
 from arelle.PythonUtil import flattenSequence
 from arelle.ValidateXbrlCalcs import roundValue
@@ -110,7 +109,7 @@ XBRLDBTABLES = {
 class XbrlSqlDatabaseConnection(SqlDbConnection):
     def verifyTables(self):
         allExtTables = set()
-        for pluginXbrlMethod in pluginClassMethods("xbrlDB.Open.Ext.TableDDLFiles"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("xbrlDB.Open.Ext.TableDDLFiles"):
             allExtTables |= pluginXbrlMethod(self)[0]
         coreAndExtTables = XBRLDBTABLES | allExtTables
         presentTables = self.tablesInDB()
@@ -125,7 +124,7 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
                                                      "postgres": "xbrlOpenPostgresDB.ddl"}[self.product]))
             presentTables.clear() # db is cleared
         # for this extension, add extension tables if any ext's tables are missing
-        for pluginXbrlMethod in pluginClassMethods("xbrlDB.Open.Ext.TableDDLFiles"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("xbrlDB.Open.Ext.TableDDLFiles"):
             _extTables, _extDdlFiles = pluginXbrlMethod(self)
             if not (presentTables & _extTables):
                 self.create(_extDdlFiles, dropPriorTables=False)
@@ -156,7 +155,7 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
 
             # obtain ext metadata
             self.metadata = loadEntityInformation(self.modelXbrl, entrypoint, rssItem)
-            for pluginXbrlMethod in pluginClassMethods("xbrlDB.Open.Ext.Metadata"):
+            for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("xbrlDB.Open.Ext.Metadata"):
                 pluginXbrlMethod(self, entrypoint, rssItem)
             # identify table facts (table datapoints) (prior to locked database transaction
             self.tableFacts = tableFacts(self.modelXbrl)  # for EFM & HMRC this is ( (roleType, table_code, fact) )
@@ -268,7 +267,7 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
                 self.arcroleHasResource[arcrole] = hasResource
 
     def initializeBatch(self, rssObject):
-        for pluginXbrlMethod in pluginClassMethods("xbrlDB.Open.Ext.InitializeBatch"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("xbrlDB.Open.Ext.InitializeBatch"):
             pluginXbrlMethod(self, rssObject)
 
 
@@ -286,12 +285,12 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
             self.submissionId = submissionId
             break
 
-        for pluginXbrlMethod in pluginClassMethods("xbrlDB.Open.Ext.ExtSubmission"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("xbrlDB.Open.Ext.ExtSubmission"):
             existingFilingId = pluginXbrlMethod(self, now)
 
         self.showStatus("insert filing")
         self.filingPk = None
-        for pluginXbrlMethod in pluginClassMethods("xbrlDB.Open.Ext.ExistingFilingPk"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("xbrlDB.Open.Ext.ExistingFilingPk"):
             self.filingPk = pluginXbrlMethod(self)
             if self.filingPk:
                 break
@@ -305,12 +304,12 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
                                   )
             for pk, in table:
                 self.filingPk = pk
-        for pluginXbrlMethod in pluginClassMethods("xbrlDB.Open.Ext.ExtFiling"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("xbrlDB.Open.Ext.ExtFiling"):
             existingFilingId = pluginXbrlMethod(self, now)
         self.showStatus("insert report")
         self.reportPk = None
         self.filingPreviouslyInDB = False
-        for pluginXbrlMethod in pluginClassMethods("xbrlDB.Open.Ext.ExistingReportPk"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("xbrlDB.Open.Ext.ExistingReportPk"):
             self.reportPk = pluginXbrlMethod(self)
             if self.reportPk:
                 self.filingPreviouslyInDB = True
@@ -331,7 +330,7 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
                 self.reportPk = pk
                 break
 
-        for pluginXbrlMethod in pluginClassMethods("xbrlDB.Open.Ext.ExtReport"):
+        for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("xbrlDB.Open.Ext.ExtReport"):
             existingFilingId = pluginXbrlMethod(self, now)
 
     def isSemanticDocument(self, modelDocument):
@@ -500,7 +499,7 @@ class XbrlSqlDatabaseConnection(SqlDbConnection):
                              ((self.reportPk, instDocId, creationSoftware,
                                instSchemaDocId),)
                             )
-            for pluginXbrlMethod in pluginClassMethods("xbrlDB.Open.Ext.ExtReportUpdate"):
+            for pluginXbrlMethod in self.modelXbrl.modelManager.cntlr.pluginManager.pluginClassMethods("xbrlDB.Open.Ext.ExtReportUpdate"):
                 existingFilingId = pluginXbrlMethod(self)
 
 

--- a/arelle/utils/EntryPointDetection.py
+++ b/arelle/utils/EntryPointDetection.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
 
 from arelle import (
-    PluginManager, FileSource, PackageManager,
+    FileSource, PackageManager,
 )
 from arelle.ModelDocumentType import ModelDocumentType
 from arelle.UrlUtil import isHttpUrl
@@ -69,7 +69,7 @@ def parseEntrypointFileInput(cntlr: Cntlr, entrypointFile: str | None, sourceZip
 def filesourceEntrypointFiles(filesource, entrypointFiles=None, inlineOnly=False, fallbackSelect=True):
     if entrypointFiles is None:
         entrypointFiles = []
-    for pluginXbrlMethod in PluginManager.pluginClassMethods("FileSource.EntrypointFiles"):
+    for pluginXbrlMethod in filesource.pluginClassMethods("FileSource.EntrypointFiles"):
         resultEntrypointFiles = pluginXbrlMethod(filesource, inlineOnly)
         if resultEntrypointFiles is not None:
             del entrypointFiles[:]  # clear list
@@ -87,7 +87,7 @@ def filesourceEntrypointFiles(filesource, entrypointFiles=None, inlineOnly=False
                 if report.isInline:
                     reportEntries = [{"file": f} for f in report.fullPathFiles]
                     ixdsDiscovered = False
-                    for pluginXbrlMethod in PluginManager.pluginClassMethods("InlineDocumentSet.Discovery"):
+                    for pluginXbrlMethod in filesource.pluginClassMethods("InlineDocumentSet.Discovery"):
                         pluginXbrlMethod(filesource, reportEntries)
                         ixdsDiscovered = True
                     if not ixdsDiscovered and len(reportEntries) > 1:
@@ -109,7 +109,7 @@ def filesourceEntrypointFiles(filesource, entrypointFiles=None, inlineOnly=False
                     discoveredEntrypointFiles.append({"file":url})
                 if discoveredEntrypointFiles:
                     if identifiedType == ModelDocumentType.INLINEXBRL:
-                        for pluginXbrlMethod in PluginManager.pluginClassMethods("InlineDocumentSet.Discovery"):
+                        for pluginXbrlMethod in filesource.pluginClassMethods("InlineDocumentSet.Discovery"):
                             pluginXbrlMethod(filesource, discoveredEntrypointFiles) # group into IXDS if plugin feature is available
                     break # found inline (or non-inline) entrypoint files, don't look for any other type
             # for ESEF non-consolidated xhtml documents accept an xhtml entry point
@@ -139,7 +139,7 @@ def filesourceEntrypointFiles(filesource, entrypointFiles=None, inlineOnly=False
                 if identifiedType in (ModelDocumentType.INSTANCE, ModelDocumentType.INLINEXBRL):
                     entrypointFiles.append({"file":_path})
         if hasInline: # group into IXDS if plugin feature is available
-            for pluginXbrlMethod in PluginManager.pluginClassMethods("InlineDocumentSet.Discovery"):
+            for pluginXbrlMethod in filesource.pluginClassMethods("InlineDocumentSet.Discovery"):
                 pluginXbrlMethod(filesource, entrypointFiles)
 
     return entrypointFiles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -189,7 +189,6 @@ module = [
     'arelle.ModelVersObject',
     'arelle.ModelVersReport',
     'arelle.PackageManager',
-    'arelle.PluginManager',
     'arelle.PrototypeDtsObject',
     'arelle.PrototypeInstanceObject',
     'arelle.PythonUtil',

--- a/tests/integration_tests/integration_test_util.py
+++ b/tests/integration_tests/integration_test_util.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, cast, Any
 import pytest
 import regex
 
-from arelle import PackageManager, PluginManager
+from arelle import PackageManager
 from arelle.ModelDocumentType import ModelDocumentType
 from arelle.Cntlr import Cntlr
 from arelle.CntlrCmdLine import parseAndRun
@@ -169,7 +169,7 @@ def get_test_data(
     finally:
         cntlr.modelManager.close()
         PackageManager.close()  # type: ignore[no-untyped-call]
-        PluginManager.close()
+        cntlr.pluginManager.close()
 
 
 def collect_test_data(

--- a/tests/integration_tests/scripts/tests/python_api_ixbrl-viewer.py
+++ b/tests/integration_tests/scripts/tests/python_api_ixbrl-viewer.py
@@ -49,7 +49,6 @@ class TestFilter(logging.Filter):
 
 
 log_filter = TestFilter()
-log_handler = StructuredMessageLogHandler()
 print(f"Generating IXBRL viewer: {viewer_path}")
 # include start
 with open(samples_zip_path, 'rb') as stream:
@@ -71,8 +70,8 @@ with open(samples_zip_path, 'rb') as stream:
         session.run(
             options,
             sourceZipStream=stream,
-            logHandler=log_handler,
             logFilters=[log_filter],
+            logFileName="logToStructuredMessage",
         )
         # Plugin default options were applied.
         assert hasattr(options, "viewerURL")
@@ -91,7 +90,6 @@ if actual_filtered != expected_filtered:
     errors.append(f'Expected {expected_filtered} filtered log records, found {actual_filtered}.')
 
 print("Checking log XML for errors...")
-assert log_xml == log_handler.getXml(clearLogBuffer=False, includeDeclaration=False)
 errors += validate_log_xml(log_xml)
 
 assert_result(errors)

--- a/tests/unit_tests/arelle/test_pluginmanager.py
+++ b/tests/unit_tests/arelle/test_pluginmanager.py
@@ -8,6 +8,7 @@ import pytest
 from unittest.mock import Mock
 
 from arelle import PluginManager
+from arelle.PluginManager import PluginManager as PluginManagerClass
 
 
 def test_plugin_manager_init_first_pass():
@@ -148,6 +149,76 @@ def test_function_loadModule():
     assert "functionsMath" in all_modules_list
 
     PluginManager.close()
+
+class TestPluginManagerClass:
+    """Tests that use the PluginManager class directly (not the module-level API)."""
+
+    def test_init_creates_instance(self):
+        cntlr = Mock(pluginDir='some_dir')
+        pm = PluginManagerClass(cntlr, loadPluginConfig=False)
+        assert len(pm.pluginConfig) == 2
+        assert 'modules' in pm.pluginConfig
+        assert 'classes' in pm.pluginConfig
+        assert len(pm.modulePluginInfos) == 0
+        assert len(pm.pluginMethodsForClasses) == 0
+        assert pm._cntlr is cntlr
+
+    def test_reset_clears_runtime_state(self):
+        cntlr = Mock(pluginDir='some_dir')
+        pm = PluginManagerClass(cntlr, loadPluginConfig=False)
+        pm.modulePluginInfos['module'] = 'plugin_info'
+        pm.pluginMethodsForClasses['class'] = 'plugin_method'
+        pm.reset()
+        assert len(pm.pluginConfig) == 2
+        assert len(pm.modulePluginInfos) == 0
+        assert len(pm.pluginMethodsForClasses) == 0
+
+    def test_close_clears_all_state(self):
+        cntlr = Mock(pluginDir='some_dir')
+        pm = PluginManagerClass(cntlr, loadPluginConfig=False)
+        pm.modulePluginInfos['module'] = 'plugin_info'
+        pm.pluginMethodsForClasses['class'] = 'plugin_method'
+        pm.close()
+        assert len(pm.pluginConfig) == 0
+        assert len(pm.modulePluginInfos) == 0
+        assert len(pm.pluginMethodsForClasses) == 0
+
+    def test_singleton_wired_after_init(self):
+        cntlr = Mock(pluginDir='some_dir')
+        PluginManager.init(cntlr, loadPluginConfig=False)
+        assert PluginManager._singleton is not None
+        assert isinstance(PluginManager._singleton, PluginManagerClass)
+        assert PluginManager._singleton._cntlr is cntlr
+
+    def test_backward_compat_getattr(self):
+        cntlr = Mock(pluginDir='some_dir')
+        PluginManager.init(cntlr, loadPluginConfig=False)
+        assert PluginManager.pluginConfig is PluginManager._singleton.pluginConfig
+        assert PluginManager._cntlr is PluginManager._singleton._cntlr
+        assert PluginManager.modulePluginInfos is PluginManager._singleton.modulePluginInfos
+
+    @pytest.mark.parametrize(
+        "test_data, expected_result",
+        [
+            (
+                (Path("arelle/plugin/non-existent-plugin"), "xyz"),
+                (None, None, None)
+            ),
+            (
+                (Path("arelle/plugin/CacheBuilder.py"), "xyz"),
+                ("CacheBuilder", "arelle/plugin", "xyz")
+            ),
+        ]
+    )
+    def test_static_get_name_dir_prefix(self, test_data, expected_result):
+        moduleName, moduleDir, packageImportPrefix = PluginManagerClass._get_name_dir_prefix(
+            modulePath=test_data[0],
+            packagePrefix=test_data[1],
+        )
+        assert moduleName == expected_result[0]
+        assert moduleDir == (None if expected_result[1] is None else os.path.normcase(expected_result[1]))
+        assert packageImportPrefix == expected_result[2]
+
 
 def teardown_function():
     PluginManager.close()

--- a/tests/unit_tests/arelle/test_pluginmanager.py
+++ b/tests/unit_tests/arelle/test_pluginmanager.py
@@ -7,8 +7,7 @@ import sys
 import pytest
 from unittest.mock import Mock
 
-from arelle import PluginManager
-from arelle.PluginManager import PluginManager as PluginManagerClass
+from arelle.PluginManager import PluginManager
 
 
 def test_plugin_manager_init_first_pass():
@@ -16,17 +15,17 @@ def test_plugin_manager_init_first_pass():
     Test that pluginConfig is correctly setup during init on fresh pass
     """
     cntlr = Mock(pluginDir='some_dir')
-    PluginManager.init(cntlr, loadPluginConfig=False)
-    assert len(PluginManager.pluginConfig) == 2
-    assert 'modules' in PluginManager.pluginConfig
-    assert isinstance(PluginManager.pluginConfig.get('modules'), dict)
-    assert len(PluginManager.pluginConfig.get('modules')) == 0
-    assert 'classes' in PluginManager.pluginConfig
-    assert isinstance(PluginManager.pluginConfig.get('classes'), dict)
-    assert len(PluginManager.pluginConfig.get('classes')) == 0
-    assert len(PluginManager.modulePluginInfos) == 0
-    assert len(PluginManager.pluginMethodsForClasses) == 0
-    assert PluginManager._cntlr == cntlr
+    pm = PluginManager(cntlr, loadPluginConfig=False)
+    assert len(pm.pluginConfig) == 2
+    assert 'modules' in pm.pluginConfig
+    assert isinstance(pm.pluginConfig.get('modules'), dict)
+    assert len(pm.pluginConfig.get('modules')) == 0
+    assert 'classes' in pm.pluginConfig
+    assert isinstance(pm.pluginConfig.get('classes'), dict)
+    assert len(pm.pluginConfig.get('classes')) == 0
+    assert len(pm.modulePluginInfos) == 0
+    assert len(pm.pluginMethodsForClasses) == 0
+    assert pm._cntlr == cntlr
 
 
 def test_plugin_manager_init_config_already_exists():
@@ -34,19 +33,19 @@ def test_plugin_manager_init_config_already_exists():
     Test that pluginConfig is correctly setup during init on a second pass
     """
     cntlr = Mock(pluginDir='some_dir')
-    PluginManager.init(cntlr, loadPluginConfig=False)
-    PluginManager.close()
-    PluginManager.init(cntlr, loadPluginConfig=False)
-    assert len(PluginManager.pluginConfig) == 2
-    assert 'modules' in PluginManager.pluginConfig
-    assert isinstance(PluginManager.pluginConfig.get('modules'), dict)
-    assert len(PluginManager.pluginConfig.get('modules')) == 0
-    assert 'classes' in PluginManager.pluginConfig
-    assert isinstance(PluginManager.pluginConfig.get('classes'), dict)
-    assert len(PluginManager.pluginConfig.get('classes')) == 0
-    assert len(PluginManager.modulePluginInfos) == 0
-    assert len(PluginManager.pluginMethodsForClasses) == 0
-    assert PluginManager._cntlr == cntlr
+    pm = PluginManager(cntlr, loadPluginConfig=False)
+    pm.close()
+    pm2 = PluginManager(cntlr, loadPluginConfig=False)
+    assert len(pm2.pluginConfig) == 2
+    assert 'modules' in pm2.pluginConfig
+    assert isinstance(pm2.pluginConfig.get('modules'), dict)
+    assert len(pm2.pluginConfig.get('modules')) == 0
+    assert 'classes' in pm2.pluginConfig
+    assert isinstance(pm2.pluginConfig.get('classes'), dict)
+    assert len(pm2.pluginConfig.get('classes')) == 0
+    assert len(pm2.modulePluginInfos) == 0
+    assert len(pm2.pluginMethodsForClasses) == 0
+    assert pm2._cntlr == cntlr
 
 
 def test_plugin_manager_close():
@@ -54,33 +53,34 @@ def test_plugin_manager_close():
     Test that pluginConfig, modulePluginInfos and pluginMethodsForClasses are cleared when close is called
     """
     cntlr = Mock(pluginDir='some_dir')
-    PluginManager.init(cntlr, loadPluginConfig=False)
-    assert len(PluginManager.modulePluginInfos) == 0
-    assert len(PluginManager.pluginMethodsForClasses) == 0
-    PluginManager.modulePluginInfos['module'] = 'plugin_info'
-    PluginManager.pluginMethodsForClasses['class'] = 'plugin_method'
-    PluginManager.close()
-    assert len(PluginManager.pluginConfig) == 0
-    assert len(PluginManager.modulePluginInfos) == 0
-    assert len(PluginManager.pluginMethodsForClasses) == 0
-    assert PluginManager._cntlr == cntlr
+    pm = PluginManager(cntlr, loadPluginConfig=False)
+    assert len(pm.modulePluginInfos) == 0
+    assert len(pm.pluginMethodsForClasses) == 0
+    pm.modulePluginInfos['module'] = 'plugin_info'
+    pm.pluginMethodsForClasses['class'] = 'plugin_method'
+    pm.close()
+    assert len(pm.pluginConfig) == 0
+    assert len(pm.modulePluginInfos) == 0
+    assert len(pm.pluginMethodsForClasses) == 0
+    assert pm._cntlr == cntlr
 
 
 def test_plugin_manager_reset():
     """
-    Test that modulePluginInfos and pluginMethodsForClasses are cleared when close is called, pluginConfig remains unchanged
+    Test that modulePluginInfos and pluginMethodsForClasses are cleared when reset is called, pluginConfig remains unchanged
     """
     cntlr = Mock(pluginDir='some_dir')
-    PluginManager.init(cntlr, loadPluginConfig=False)
-    assert len(PluginManager.modulePluginInfos) == 0
-    assert len(PluginManager.pluginMethodsForClasses) == 0
-    PluginManager.modulePluginInfos['module'] = 'plugin_info'
-    PluginManager.pluginMethodsForClasses['class'] = 'plugin_method'
-    PluginManager.reset()
-    assert len(PluginManager.pluginConfig) == 2
-    assert len(PluginManager.modulePluginInfos) == 0
-    assert len(PluginManager.pluginMethodsForClasses) == 0
-    assert PluginManager._cntlr == cntlr
+    pm = PluginManager(cntlr, loadPluginConfig=False)
+    assert len(pm.modulePluginInfos) == 0
+    assert len(pm.pluginMethodsForClasses) == 0
+    pm.modulePluginInfos['module'] = 'plugin_info'
+    pm.pluginMethodsForClasses['class'] = 'plugin_method'
+    pm.reset()
+    assert len(pm.pluginConfig) == 2
+    assert len(pm.modulePluginInfos) == 0
+    assert len(pm.pluginMethodsForClasses) == 0
+    assert pm._cntlr == cntlr
+
 
 @pytest.mark.parametrize(
     "test_data, expected_result",
@@ -122,7 +122,6 @@ def test_function_get_name_dir_prefix(
     assert moduleDir == (None if expected_result[1] is None else os.path.normcase(expected_result[1]))
     assert packageImportPrefix == expected_result[2]
 
-    PluginManager.close()
 
 def test_function_loadModule():
     """
@@ -131,8 +130,10 @@ def test_function_loadModule():
     This test asserts that a plugin module is loaded when running
     the function.
     """
+    cntlr = Mock(pluginDir='some_dir')
+    pm = PluginManager(cntlr, loadPluginConfig=False)
 
-    PluginManager.loadModule(
+    pm.loadModule(
         moduleInfo={
             "name": "mock",
             "moduleURL": "functionsMath",
@@ -147,78 +148,3 @@ def test_function_loadModule():
     assert "arelle.FunctionXs" in all_modules_list
     assert "isodate.isoduration" in all_modules_list
     assert "functionsMath" in all_modules_list
-
-    PluginManager.close()
-
-class TestPluginManagerClass:
-    """Tests that use the PluginManager class directly (not the module-level API)."""
-
-    def test_init_creates_instance(self):
-        cntlr = Mock(pluginDir='some_dir')
-        pm = PluginManagerClass(cntlr, loadPluginConfig=False)
-        assert len(pm.pluginConfig) == 2
-        assert 'modules' in pm.pluginConfig
-        assert 'classes' in pm.pluginConfig
-        assert len(pm.modulePluginInfos) == 0
-        assert len(pm.pluginMethodsForClasses) == 0
-        assert pm._cntlr is cntlr
-
-    def test_reset_clears_runtime_state(self):
-        cntlr = Mock(pluginDir='some_dir')
-        pm = PluginManagerClass(cntlr, loadPluginConfig=False)
-        pm.modulePluginInfos['module'] = 'plugin_info'
-        pm.pluginMethodsForClasses['class'] = 'plugin_method'
-        pm.reset()
-        assert len(pm.pluginConfig) == 2
-        assert len(pm.modulePluginInfos) == 0
-        assert len(pm.pluginMethodsForClasses) == 0
-
-    def test_close_clears_all_state(self):
-        cntlr = Mock(pluginDir='some_dir')
-        pm = PluginManagerClass(cntlr, loadPluginConfig=False)
-        pm.modulePluginInfos['module'] = 'plugin_info'
-        pm.pluginMethodsForClasses['class'] = 'plugin_method'
-        pm.close()
-        assert len(pm.pluginConfig) == 0
-        assert len(pm.modulePluginInfos) == 0
-        assert len(pm.pluginMethodsForClasses) == 0
-
-    def test_singleton_wired_after_init(self):
-        cntlr = Mock(pluginDir='some_dir')
-        PluginManager.init(cntlr, loadPluginConfig=False)
-        assert PluginManager._singleton is not None
-        assert isinstance(PluginManager._singleton, PluginManagerClass)
-        assert PluginManager._singleton._cntlr is cntlr
-
-    def test_backward_compat_getattr(self):
-        cntlr = Mock(pluginDir='some_dir')
-        PluginManager.init(cntlr, loadPluginConfig=False)
-        assert PluginManager.pluginConfig is PluginManager._singleton.pluginConfig
-        assert PluginManager._cntlr is PluginManager._singleton._cntlr
-        assert PluginManager.modulePluginInfos is PluginManager._singleton.modulePluginInfos
-
-    @pytest.mark.parametrize(
-        "test_data, expected_result",
-        [
-            (
-                (Path("arelle/plugin/non-existent-plugin"), "xyz"),
-                (None, None, None)
-            ),
-            (
-                (Path("arelle/plugin/CacheBuilder.py"), "xyz"),
-                ("CacheBuilder", "arelle/plugin", "xyz")
-            ),
-        ]
-    )
-    def test_static_get_name_dir_prefix(self, test_data, expected_result):
-        moduleName, moduleDir, packageImportPrefix = PluginManagerClass._get_name_dir_prefix(
-            modulePath=test_data[0],
-            packagePrefix=test_data[1],
-        )
-        assert moduleName == expected_result[0]
-        assert moduleDir == (None if expected_result[1] is None else os.path.normcase(expected_result[1]))
-        assert packageImportPrefix == expected_result[2]
-
-
-def teardown_function():
-    PluginManager.close()


### PR DESCRIPTION
# PluginManager Class Refactor

> [!IMPORTANT]
> This PR is not meant to be merged at once, but is rather a holding place for three distinct sets of changes, detailed below. 

## Goal: 
Replace PluginManager's module-level global state and free functions with a single `PluginManager` class, inject it via the controller (`cntlr.pluginManager`), and remove the legacy module-level API.

## Release Strategy:

- Release 1: Non-breaking Internal Changes ([commits](https://github.com/aaroncameron-wk/arelle-public/pull/179/changes/BASE..dd8b411f09762361c57d0e9f653c150e1f35a815?w=1#diff-66c8376820d75f674b7add71ac44e4bdff81134ea56636875ce8f83522ecf514))
  - **In-place refactor:** Introduce the `PluginManager` class by wrapping existing logic (add class, indent, add `self`) rather than moving large blocks of code, so diffs stay reviewable.
  - **Temporary backward compatibility:** Keep a module-level singleton and thin wrappers so existing "static-style" callers keep working.
- Release 2: Deprecation Warning ([commits](https://github.com/aaroncameron-wk/arelle-public/pull/179/changes/146e117e8b8163aa59ea2b960015f7f25c06081e))
  - After announcing this plan to give API users and plugin maintainers an opportunity to adopt early, add deprecation warnings.
- Release 3: Remove Legacy API ([commits](https://github.com/aaroncameron-wk/arelle-public/pull/179/changes/73526e4726f10c2a7d6e55ae8a967faf018d24e0))
  - After sufficient time has passed with deprecation warnings in place, remove the legacy API entirely.